### PR TITLE
refactor: 将 ES 模块格式检测从路由核心移到视图组件

### DIFF
--- a/packages/router-vue2/src/view.ts
+++ b/packages/router-vue2/src/view.ts
@@ -6,6 +6,10 @@ declare module 'vue/types' {
     }
 }
 
+function isESModule(obj: any): boolean {
+    return Boolean(obj?.__esModule) || obj?.[Symbol.toStringTag] === 'Module';
+}
+
 export const RouterView = defineComponent({
     functional: true,
     render(h, ctx) {
@@ -38,6 +42,12 @@ export const RouterView = defineComponent({
             return h();
         }
 
-        return h(matchRoute.component, data);
+        // 处理 ES 模块格式的组件
+        let componentToRender = matchRoute.component;
+        if (isESModule(componentToRender)) {
+            componentToRender = componentToRender.default || componentToRender;
+        }
+
+        return h(componentToRender, data);
     }
 });

--- a/packages/router-vue3/src/view.ts
+++ b/packages/router-vue3/src/view.ts
@@ -15,6 +15,10 @@ import {
 
 import { routerViewDepthKey, routerViewLocationKey } from './symbols';
 
+function isESModule(obj: any): boolean {
+    return Boolean(obj?.__esModule) || obj?.[Symbol.toStringTag] === 'Module';
+}
+
 export const RouterView = defineComponent({
     name: 'RouterView',
     inheritAttrs: true,
@@ -74,8 +78,15 @@ export const RouterView = defineComponent({
                 return null;
             }
 
+            // 处理 ES 模块格式的组件
+            let componentToRender = matchRoute.component;
+            if (isESModule(componentToRender)) {
+                componentToRender =
+                    componentToRender.default || componentToRender;
+            }
+
             const component = h(
-                matchRoute.component,
+                componentToRender,
                 Object.assign({}, props, attrs)
             );
             return (

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -24,12 +24,7 @@ import type {
     RouterOptions,
     RouterParsedOptions
 } from './types';
-import {
-    isESModule,
-    isUrlEqual,
-    isValidConfirmHookResult,
-    removeFromArray
-} from './util';
+import { isUrlEqual, isValidConfirmHookResult, removeFromArray } from './util';
 
 export class Router {
     public readonly options: RouterOptions;
@@ -75,9 +70,7 @@ export class Router {
                     if (!component && typeof asyncComponent === 'function') {
                         try {
                             const result = await asyncComponent();
-                            matched.component = isESModule(result)
-                                ? result.default
-                                : result;
+                            matched.component = result;
                         } catch {
                             throw new Error(
                                 `Async component '${matched.compilePath}' is not a valid component.`

--- a/packages/router/src/util.test.ts
+++ b/packages/router/src/util.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
 import {
-    isESModule,
     isNonEmptyPlainObject,
     isNotNullish,
     isPlainObject,
@@ -10,58 +9,6 @@ import {
 } from './util';
 
 const AsyncFunction = (async () => {}).constructor;
-
-describe('isESModule', () => {
-    test('should return true for ES module', () => {
-        const esModule = { __esModule: true };
-        expect(isESModule(esModule)).toBe(true);
-    });
-
-    test('should return true for module with Symbol.toStringTag', () => {
-        const module = { [Symbol.toStringTag]: 'Module' };
-        expect(isESModule(module)).toBe(true);
-    });
-
-    test('should return false for non-ES module', () => {
-        const obj = {};
-        expect(isESModule(obj)).toBe(false);
-    });
-
-    test('should handle edge cases', () => {
-        expect(isESModule(null)).toBe(false);
-        expect(isESModule(void 0)).toBe(false);
-
-        // 原始类型
-        expect(isESModule(123)).toBe(false);
-        expect(isESModule('string')).toBe(false);
-        expect(isESModule(true)).toBe(false);
-        expect(isESModule(Symbol('test'))).toBe(false);
-
-        // 包含 __esModule 但值为 falsy 的情况
-        expect(isESModule({ __esModule: false })).toBe(false);
-        expect(isESModule({ __esModule: 0 })).toBe(false);
-        expect(isESModule({ __esModule: '' })).toBe(false);
-        expect(isESModule({ __esModule: null })).toBe(false);
-        expect(isESModule({ __esModule: void 0 })).toBe(false);
-
-        // 包含 Symbol.toStringTag 但值不是 'Module' 的情况
-        expect(isESModule({ [Symbol.toStringTag]: 'Object' })).toBe(false);
-        expect(isESModule({ [Symbol.toStringTag]: 'Array' })).toBe(false);
-        expect(isESModule({ [Symbol.toStringTag]: null })).toBe(false);
-        expect(isESModule({ [Symbol.toStringTag]: void 0 })).toBe(false);
-
-        // 同时包含两个属性的情况
-        expect(
-            isESModule({ __esModule: true, [Symbol.toStringTag]: 'Module' })
-        ).toBe(true);
-        expect(
-            isESModule({ __esModule: false, [Symbol.toStringTag]: 'Module' })
-        ).toBe(true);
-        expect(
-            isESModule({ __esModule: true, [Symbol.toStringTag]: 'Object' })
-        ).toBe(true);
-    });
-});
 
 // 字面量和对象包装是存在区别的：
 // https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String#字符串原始值和字符串对象
@@ -821,7 +768,6 @@ describe('Performance Tests', () => {
         for (let i = 0; i < iterations; ++i) {
             isNotNullish(i);
             isPlainObject({ value: i });
-            isESModule({ __esModule: true });
             isValidConfirmHookResult(false);
         }
 

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -36,10 +36,6 @@ export function isNonEmptyPlainObject(
     return Object.keys(value as Record<string, any>).length > 0;
 }
 
-export function isESModule(obj: any): boolean {
-    return Boolean(obj?.__esModule) || obj?.[Symbol.toStringTag] === 'Module';
-}
-
 export const removeFromArray = <T>(arr: T[], ele: T) => {
     if (!Array.isArray(arr) || arr.length === 0) return;
     const i = Number.isNaN(ele)


### PR DESCRIPTION
## 📋 变更内容

将 ES 模块格式检测逻辑从路由核心移动到框架特定的视图组件中，提高架构的合理性和扩展性。

## 🔄 主要修改

### Router 核心
- **`packages/router/src/router.ts`**: 移除 `isESModule` 导入和使用
- **`packages/router/src/util.ts`**: 完全移除 `isESModule` 函数  
- **`packages/router/src/util.test.ts`**: 移除相关测试

### Vue 组件
- **`packages/router-vue3/src/view.ts`**: 添加本地 `isESModule` 函数并在渲染时处理
- **`packages/router-vue2/src/view.ts`**: 添加本地 `isESModule` 函数并在渲染时处理

## 🎯 重构优势

1. **更好的关注点分离**: 路由核心专注路由逻辑，视图组件处理渲染细节
2. **框架无关性**: 路由核心不再绑定特定模块系统  
3. **增强扩展性**: 不同框架可根据需要自定义组件处理逻辑
4. **遵循单一职责**: 模块格式检测属于渲染层责任
5. **向后兼容**: 用户无需修改代码，功能保持一致

## ✅ 测试验证

- ✅ Router 包所有测试通过 (461 个测试)
- ✅ Vue2/Vue3 组件构建成功
- ✅ TypeScript 类型检查通过
- ✅ 代码风格检查通过

## 🔗 相关 Issue

Closes #92 