### PR TITLE
refactor: centralize ESM configurations in rspack-module-link-plugin

### DIFF
--- a/examples/router-demo-vue2/src/components/collapsible-json.vue
+++ b/examples/router-demo-vue2/src/components/collapsible-json.vue
@@ -34,7 +34,10 @@ const replacer = (k: string, v: any) => {
                 return `\x01json-unknown\x04[object RegExp( ${v.toString()} )]`;
             }
             if (v instanceof Set || v instanceof Map) {
-                return ('\x01json-unknown\x04' + v.toString()).replace(/\]/, `(${v.size})]`);
+                return ('\x01json-unknown\x04' + v.toString()).replace(
+                    /\]/,
+                    `(${v.size})]`
+                );
             }
     }
     return v;
@@ -42,9 +45,15 @@ const replacer = (k: string, v: any) => {
 
 const vHTML = computed(() =>
     JSON.stringify(props.data, replacer, space)
-        .replace(/^(.*)"\\u0001json-unknown(\\u.*)"(,?)$/gm,'json-unknown$1$2$3')
+        .replace(
+            /^(.*)"\\u0001json-unknown(\\u.*)"(,?)$/gm,
+            'json-unknown$1$2$3'
+        )
         .replace(/^( *)(".*?"):/gm, '$1<span class="json-key">$2</span>:')
-        .replace(/(^ *|: )(".*")(,?)$/gm, '$1<span class="json-str">$2</span>$3')
+        .replace(
+            /(^ *|: )(".*")(,?)$/gm,
+            '$1<span class="json-str">$2</span>$3'
+        )
         .replace(
             /(^ *|: )(null|true|false)(,?)$/gm,
             '$1<span class="json-keyword">$2</span>$3'
@@ -79,30 +88,41 @@ const vHTML = computed(() =>
         .replace(
             /json-unknown( *)(?:(".*?"): )?\\u0002(\d+)(,?$\n?)/gm,
             (all, spaces, key, funcId, end) => {
-                key = key === void 0 ? '' : `<span class="json-key">${key}</span>: `;
+                key =
+                    key === void 0
+                        ? ''
+                        : `<span class="json-key">${key}</span>: `;
                 let func = fnCache[funcId];
                 Reflect.deleteProperty(fnCache, funcId);
                 func = func.toString();
                 const line1 = func.split('\n')[0];
                 let otherLines = func.replace(line1, '');
-                const len = otherLines.replace(/.*^( *)}\)?/sm, '$1').length;
-                otherLines = otherLines.replace(new RegExp('^' + (' '.repeat(len)), 'gm'), '');
-                let ellipsis = line1.startsWith('function') || line1.startsWith('async function')
-                    ? ' ... }'
-                    : otherLines.length > 0
-                        ? ' ... ' + (line1.endsWith('({') ? '})' : '}')
-                        : '';
-                ellipsis = ellipsis.length ? `<span class="json-ellipsis">${ellipsis}</span>` : '';
+                const len = otherLines.replace(/.*^( *)}\)?/ms, '$1').length;
+                otherLines = otherLines.replace(
+                    new RegExp('^' + ' '.repeat(len), 'gm'),
+                    ''
+                );
+                let ellipsis =
+                    line1.startsWith('function') ||
+                    line1.startsWith('async function')
+                        ? ' ... }'
+                        : otherLines.length > 0
+                          ? ' ... ' + (line1.endsWith('({') ? '})' : '}')
+                          : '';
+                ellipsis = ellipsis.length
+                    ? `<span class="json-ellipsis">${ellipsis}</span>`
+                    : '';
                 const fnCollapse = `<details class="json-function"
                         ><summary>${line1}${ellipsis}</summary
                         ><pre>${otherLines}</pre
                     ></details
                 >`;
-                return (key
-                    ? `<i class="json-unknown">${spaces}${key}${fnCollapse}${end}</i>`
-                    : `${spaces}<span class="json-keyword">null</span>${
-                            end.includes(',')? ',': ''
-                        }<i class="json-unknown"> ${fnCollapse}${end.includes('\n')? '\n': ''}</i>`
+                return (
+                    key
+                        ? `<i class="json-unknown">${spaces}${key}${fnCollapse}${end}</i>`
+                        : `${spaces}<span class="json-keyword">null</span>${
+                              end.includes(',') ? ',' : ''
+                          }<i class="json-unknown"> ${fnCollapse}${end.includes('\n') ? '\n' : ''}</i>`
                 ).replace(/\n +>/g, '>');
             }
         )

--- a/packages/rspack-module-link-plugin/src/config.ts
+++ b/packages/rspack-module-link-plugin/src/config.ts
@@ -8,14 +8,28 @@ export function initConfig(
     const isProduction = options.mode === 'production';
     options.experiments = {
         ...options.experiments,
-        outputModule: true
+        outputModule: true,
+        rspackFuture: {
+            bundlerInfo: { force: false }
+        }
+    };
+    options.module = {
+        ...options.module,
+        parser: {
+            ...options.module?.parser,
+            javascript: {
+                ...options.module?.parser?.javascript,
+                importMeta: false,
+                strictExportPresence: true
+            }
+        }
     };
     options.output = {
         ...options.output,
         iife: false,
         uniqueName: opts.name,
-        chunkFormat: isProduction ? 'module' : undefined,
-        chunkLoading: isProduction ? 'import' : undefined,
+        chunkFormat: isProduction ? 'module' : 'array-push',
+        chunkLoading: isProduction ? 'import' : 'jsonp',
         module: true,
         library: {
             type: isProduction ? 'modern-module' : 'module'

--- a/packages/rspack/src/config.ts
+++ b/packages/rspack/src/config.ts
@@ -36,15 +36,9 @@ export function createRspackConfig(
         })(),
         output: {
             clean: esmx.isProd,
-            module: true,
-            chunkFormat: esmx.isProd ? 'module' : 'array-push',
-            chunkLoading: esmx.isProd ? 'import' : 'jsonp',
             chunkFilename: esmx.isProd
                 ? '[name].[contenthash:8].final.mjs'
                 : '[name].mjs',
-            library: {
-                type: esmx.isProd ? 'modern-module' : 'module'
-            },
             filename:
                 buildTarget !== 'node' && esmx.isProd
                     ? '[name].[contenthash:8].final.mjs'
@@ -72,32 +66,21 @@ export function createRspackConfig(
                     case 'node':
                         return esmx.resolvePath('dist/node');
                 }
-            })(),
-            environment: {
-                dynamicImport: true,
-                dynamicImportInWorker: true,
-                module: true,
-                nodePrefixForCoreModules: true
-            }
+            })()
         },
-        // 默认插件，不可修改
         plugins: ((): Plugins => {
             return [
-                // 进度条插件
                 new rspack.ProgressPlugin({
                     prefix: buildTarget
                 }),
                 createModuleLinkPlugin(esmx, buildTarget),
-                // 热更新插件
                 isHot ? new rspack.HotModuleReplacementPlugin() : false
             ];
         })(),
         module: {
             parser: {
                 javascript: {
-                    url: buildTarget === 'client' ? true : 'relative',
-                    importMeta: false,
-                    strictExportPresence: true
+                    url: buildTarget === 'client' ? true : 'relative'
                 }
             },
             generator: {
@@ -117,8 +100,6 @@ export function createRspackConfig(
         },
         optimization: {
             minimize: options.minimize ?? esmx.isProd,
-            avoidEntryIife: esmx.isProd,
-            concatenateModules: esmx.isProd,
             emitOnErrors: true,
             splitChunks: {
                 chunks: 'async'
@@ -141,13 +122,6 @@ export function createRspackConfig(
             }
             return [];
         })(),
-        experiments: {
-            outputModule: true,
-            parallelCodeSplitting: true,
-            rspackFuture: {
-                bundlerInfo: { force: false }
-            }
-        },
         target: buildTarget === 'client' ? 'web' : 'node22.6',
         mode: esmx.isProd ? 'production' : 'development',
         cache: !esmx.isProd


### PR DESCRIPTION
## Summary
This PR centralizes all ESM-related configurations in the rspack-module-link-plugin package, removing duplicated configurations from the rspack package.

## Changes
- Move `experiments.outputModule` to rspack-module-link-plugin
- Move `experiments.rspackFuture` to rspack-module-link-plugin
- Move `module.parser.javascript` configurations to rspack-module-link-plugin
- Keep environment-specific configurations for development and production

## Breaking Changes
This is a breaking change as it moves configuration options between packages. Users who were previously setting these options in rspack will need to update their configuration.

## Motivation
The rspack-module-link-plugin is designed for ESM module handling, so it makes more sense to centralize all ESM-related configurations in this plugin. This change:
- Reduces configuration duplication
- Makes the responsibility boundary clearer
- Improves maintainability