### PR TITLE
fix(router): improve router-link reactivity and parameter naming

### DIFF
--- a/packages/router-vue/src/use.ts
+++ b/packages/router-vue/src/use.ts
@@ -311,6 +311,11 @@ export function useProvideRouter(router: Router): void {
  */
 export function useLink(props: RouterLinkProps) {
     const router = useRouter();
+    const route = useRoute();
 
-    return computed(() => router.resolveLink(props));
+    return computed(() => {
+        // vue will trigger a re-render when route.fullPath changes
+        route.fullPath;
+        return router.resolveLink(props);
+    });
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -167,7 +167,7 @@ export class Router {
     /**
      * Check if the route matches the current route
      *
-     * @param targetRoute Target route object to compare
+     * @param toRoute Target route object to compare
      * @param matchType Match type
      * - 'route': Route-level matching, compare if route configurations are the same
      * - 'exact': Exact matching, compare if paths are completely the same
@@ -175,13 +175,13 @@ export class Router {
      * @returns Whether it matches
      */
     public isRouteMatched(
-        targetRoute: Route,
+        toRoute: Route,
         matchType: RouteMatchType = 'include'
     ): boolean {
         const currentRoute = this.transition.route;
         if (!currentRoute) return false;
 
-        return isRouteMatched(currentRoute, targetRoute, matchType);
+        return isRouteMatched(currentRoute, toRoute, matchType);
     }
 
     /**

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -82,8 +82,8 @@ export function isUrlEqual(url1: URL, url2?: URL | null): boolean {
 /**
  * Compare if two routes match
  *
- * @param route1 First route object
- * @param route2 Second route object, may be null
+ * @param fromRoute First route object
+ * @param toRoute Second route object, may be null
  * @param matchType Match type
  * - 'route': Route-level matching, compare if route configurations are the same
  * - 'exact': Exact matching, compare if full paths are the same
@@ -91,24 +91,24 @@ export function isUrlEqual(url1: URL, url2?: URL | null): boolean {
  * @returns Whether they match
  */
 export function isRouteMatched(
-    route1: Route,
-    route2: Route | null,
+    fromRoute: Route,
+    toRoute: Route | null,
     matchType: RouteMatchType
 ): boolean {
-    if (!route2) return false;
+    if (!toRoute) return false;
 
     switch (matchType) {
         case 'route':
             // Route-level matching - compare route configurations
-            return route1.config === route2.config;
+            return fromRoute.config === toRoute.config;
 
         case 'exact':
             // Exact matching - full paths are identical
-            return route1.fullPath === route2.fullPath;
+            return fromRoute.fullPath === toRoute.fullPath;
 
         case 'include':
             // Include matching - route1 path contains route2 path
-            return route1.fullPath.startsWith(route2.fullPath);
+            return fromRoute.fullPath.startsWith(toRoute.fullPath);
 
         default:
             return false;


### PR DESCRIPTION
## Problem

1. The  hook in router-vue package doesn't properly update when the current route changes
2. Parameter names in router utils aren't descriptive or consistent

## Changes

This PR includes two improvements:

1. **RouterLink reactivity enhancement**:
   - Added route dependency to useLink computed property
   - This ensures router links refresh when the route changes
   - Fixed reactive updates without requiring manual refreshes

2. **Parameter naming consistency**:
   - Renamed parameters in isRouteMatched function:
     - route1 → fromRoute
     - route2 → toRoute
   - Updated corresponding JSDoc comments
   - Made similar changes to Router class for consistency

## Testing

- Manually verified the RouterLink component properly updates when route changes
- All existing functionality works as expected
- No regressions identified

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update