### PR TITLE
fix(core): handle incompatible legacy manifest format

### DIFF
--- a/packages/core/src/utils/import-map.test.ts
+++ b/packages/core/src/utils/import-map.test.ts
@@ -1,4 +1,4 @@
-import { assert, test } from 'vitest';
+import { assert, expect, test } from 'vitest';
 import { getImportMap } from './import-map';
 
 test('should return empty import map when no manifests provided', async () => {
@@ -116,4 +116,30 @@ test('should generate import map with remote exports and module scopes', async (
             '/ssr-vue2-host/': { vue: 'ssr-vue2-remote/vue3' }
         }
     });
+});
+
+test('should throw error when encountering legacy format manifests', async () => {
+    // 模拟旧版本的清单格式，其中 exports 的值是字符串而不是对象
+    const legacyManifest = {
+        name: 'legacy-module',
+        imports: {},
+        exports: {
+            'legacy-export': 'legacy-module/legacy-file.js'
+        } as any
+    };
+
+    const expectedErrorMessage =
+        'Detected incompatible legacy manifest format in legacy-module. Please upgrade your ESMX dependencies first, then rebuild and redeploy your service.';
+
+    expect(() => {
+        getImportMap({
+            manifests: [legacyManifest],
+            getScope(name) {
+                return `/${name}/`;
+            },
+            getFile(name, file) {
+                return `${name}/${file}`;
+            }
+        });
+    }).toThrowError(expectedErrorMessage);
 });

--- a/packages/core/src/utils/import-map.ts
+++ b/packages/core/src/utils/import-map.ts
@@ -30,7 +30,14 @@ export function getImportMap({
     Object.values(manifests).forEach((manifest) => {
         const scopeImports: SpecifierMap = {};
 
-        Object.values(manifest.exports).forEach((exportItem) => {
+        Object.entries(manifest.exports).forEach(([key, exportItem]) => {
+            // Handle the case where exportItem is a string in legacy builds
+            if (typeof exportItem === 'string') {
+                throw new Error(
+                    `Detected incompatible legacy manifest format in ${manifest.name}. Please upgrade your ESMX dependencies first, then rebuild and redeploy your service.`
+                );
+            }
+
             const file = getFile(manifest.name, exportItem.file);
             imports[exportItem.identifier] = file;
             if (!exportItem.rewrite) {


### PR DESCRIPTION
## Issue

When processing the ESM import map, encountering legacy build artifacts (where exportItem is a string) causes application exceptions.

## Changes

1. Added detection for cases where  is a string in 
2. When detecting legacy format, throws a clear error message prompting users to upgrade dependencies and rebuild/redeploy
3. Added corresponding test cases to verify error handling logic

## Testing

Added test cases verifying that when incompatible legacy formats are encountered, appropriate errors are thrown with clear messages.