### PR TITLE
fix(rspack): update node entry import path to match new exports directory structure

### DIFF
--- a/packages/rspack/src/app.ts
+++ b/packages/rspack/src/app.ts
@@ -294,7 +294,7 @@ function rewriteBuild(esmx: Esmx, options: RspackAppOptions = {}) {
             esmx.resolvePath('dist/index.mjs'),
             `
 async function start() {
-    const options = await import('./node/src/entry.node.mjs').then(
+    const options = await import('./node/exports/src/entry.node.mjs').then(
         (mod) => mod.default
     );
     const { Esmx } = await import('@esmx/core');


### PR DESCRIPTION
## Issue
After PR #121 optimized the resource output directory structure by moving export modules to the `exports/` directory, the application startup file was not correctly updated to reference this new path. This caused built applications to fail when starting.

## Fix
Updated the startup file generation in the `rewriteBuild` function to correctly reference the new export module path:

```diff
- const options = await import('./node/src/entry.node.mjs').then(
+ const options = await import('./node/exports/src/entry.node.mjs').then(
```

This change ensures the application correctly loads the Node entry module from the new location after building.

## Impact
- Only affects the generated startup file
- Fixes application startup after using the `esmx build` command
- Maintains compatibility with the directory structure optimization from PR #121

## Testing
Verified that applications can properly start after building with this fix in place, confirming compatibility with the optimized resource directory structure.