### PR TITLE
docs(core): translate manifest-json comments to English

### DIFF
--- a/packages/core/src/manifest-json.ts
+++ b/packages/core/src/manifest-json.ts
@@ -6,55 +6,55 @@ import type { ParsedModuleConfig } from './module-config';
 
 export interface ManifestJson {
     /**
-     * 模块名称
+     * Module name
      */
     name: string;
     /**
-     * 导入映射
+     * Import mappings
      */
     imports: Record<string, string>;
     /**
-     * 导出项配置
-     * 类型：Record<导出路径, 导出项信息>
+     * Export item configuration
+     * Type: Record<export path, export item information>
      */
     exports: ManifestJsonExports;
     /**
-     * 构建产物文件列表
+     * Build output file list
      */
     buildFiles: string[];
     /**
-     * 编译的文件信息
-     * 类型：Record<源文件, 编译信息>
+     * Compiled file information
+     * Type: Record<source file, compilation information>
      */
     chunks: ManifestJsonChunks;
 }
 
 /**
- * 导出项配置映射
- * 类型：Record<导出路径, 导出项信息>
+ * Export item configuration mapping
+ * Type: Record<export path, export item information>
  */
 export type ManifestJsonExports = Record<string, ManifestJsonExport>;
 
 /**
- * 导出项信息
+ * Export item information
  */
 export interface ManifestJsonExport {
     /**
-     * 导出项名称
+     * Export item name
      */
     name: string;
     /**
-     * 是否重写模块内的导入路径
-     * - true: 重写为 '{服务名}/{导出名}' 格式
-     * - false: 保持原始导入路径
+     * Whether to rewrite module import paths
+     * - true: Rewrite to '{serviceName}/{exportName}' format
+     * - false: Maintain original import paths
      */
     rewrite: boolean;
     /**
-     * 导出项对应的文件路径
+     * File path corresponding to the export item
      */
     file: string;
     /**
-     * 导出项的标识符
+     * Identifier for the export item
      */
     identifier: string;
 }
@@ -64,40 +64,40 @@ export type ManifestJsonChunks = Record<string, ManifestJsonChunk>;
 export interface ManifestJsonChunk {
     name: string;
     /**
-     * 当前编译的 JS 文件。
+     * Current compiled JS file.
      */
     js: string;
     /**
-     * 当前编译的 CSS 文件。
+     * Current compiled CSS files.
      */
     css: string[];
     /**
-     * 其它的资源文件。
+     * Other resource files.
      */
     resources: string[];
     /**
-     * 构建产物的大小。
+     * Build output sizes.
      */
     sizes: ManifestJsonChunkSizes;
 }
 
 export interface ManifestJsonChunkSizes {
     /**
-     * JavaScript 文件的大小，单位：字节
+     * JavaScript file size in bytes
      */
     js: number;
     /**
-     * CSS 文件的大小，单位：字节
+     * CSS file size in bytes
      */
     css: number;
     /**
-     * 资源文件的大小，单位：字节
+     * Resource file size in bytes
      */
     resource: number;
 }
 
 /**
- * 获取服务清单文件
+ * Get service manifest files
  */
 export async function getManifestList(
     target: BuildSsrTarget,


### PR DESCRIPTION
**Feature Description:**
Translate Chinese comments to English in manifest-json.ts file to improve readability for international developers.

**Implementation Details:**
- Translated all interface field description comments
- Translated all type definition comments
- Translated function-level comments
- Maintained the original JSDoc comment format and style
- Preserved the detail level and content integrity of all comments

**Testing:**
Verified translation accuracy and format integrity through code review, ensuring no functional changes were introduced.

**Potential Impact:**
This is a pure documentation update with no impact on code functionality or runtime behavior. It only improves the ability of non-Chinese developers to read and understand the code.

**Additional Notes:**
This is part of documentation internationalization efforts, with possible future translations of Chinese comments in other files.