### PR TITLE
fix(router): remove Object.freeze from state creation in push and rep…

### DIFF
--- a/packages/router/src/navigation.ts
+++ b/packages/router/src/navigation.ts
@@ -48,10 +48,10 @@ export class Navigation {
         data: any,
         url?: string | URL | null
     ): RouteState {
-        const state = Object.freeze({
+        const state = {
             ...(data || {}),
             [PAGE_ID_KEY]: PAGE_ID.next()
-        });
+        };
         history.pushState(state, '', url);
         return state;
     }
@@ -62,10 +62,10 @@ export class Navigation {
         url?: string | URL | null
     ): RouteState {
         const oldId = history.state?.[PAGE_ID_KEY];
-        const state = Object.freeze({
+        const state = {
             ...(data || {}),
             [PAGE_ID_KEY]: typeof oldId === 'number' ? oldId : PAGE_ID.next()
-        });
+        };
         history.replaceState(state, '', url);
         return state;
     }


### PR DESCRIPTION
Some third parties may override methods in the window.history object to modify state data.