### PR TITLE
docs: unify Module Link to Module Linking terminology

### DIFF
--- a/examples/docs/src/en/api/core/module-config.md
+++ b/examples/docs/src/en/api/core/module-config.md
@@ -24,7 +24,7 @@ interface ModuleConfig {
 ### links
 
 * **Type**: `Record<string, string>`
-* **Description**: Module link configuration. Key is remote module name, value is module build output directory path.
+* **Description**: Module linking configuration. Key is remote module name, value is module build output directory path.
 
 ### imports  
 

--- a/examples/docs/src/en/guide/essentials/_meta.json
+++ b/examples/docs/src/en/guide/essentials/_meta.json
@@ -5,5 +5,5 @@
     "csr",
     "alias",
     "base-path",
-    "module-link"
+    "module-linking"
 ]

--- a/examples/docs/src/en/guide/essentials/alias.md
+++ b/examples/docs/src/en/guide/essentials/alias.md
@@ -99,7 +99,7 @@ import type { UserInfo } from 'your-app-name/src/types';
 
 ### Cross-Service Imports
 
-When module linking (Module Link) is configured, modules from other services can be imported in the same way:
+When Module Linking is configured, modules from other services can be imported in the same way:
 
 ```ts
 // Importing components from a remote service

--- a/examples/docs/src/en/guide/essentials/module-linking.md
+++ b/examples/docs/src/en/guide/essentials/module-linking.md
@@ -1,17 +1,17 @@
 ---
 titleSuffix: Esmx Module Code Sharing
-description: "Esmx Module Link: Zero Runtime Micro-frontend Code Sharing Solution Based on ESM Standards"
+description: "Esmx Module Linking: Zero Runtime Micro-frontend Code Sharing Solution Based on ESM Standards"
 head:
   - - meta
     - property: keywords
-      content: Esmx, Module Link, ESM, Code Sharing, Micro-frontend
+      content: Esmx, Module Linking, ESM, Code Sharing, Micro-frontend
 ---
 
-# Module Link
+# Module Linking
 
-Module Link is Esmx's cross-application code sharing mechanism, based on ECMAScript module standards, achieving micro-frontend architecture with zero runtime overhead.
+Module Linking is Esmx's cross-application code sharing mechanism, based on ECMAScript module standards, achieving micro-frontend architecture with zero runtime overhead.
 
-## Why Module Link?
+## Why Module Linking?
 
 In micro-frontend architectures, multiple independent applications often need to use the same third-party libraries (such as HTTP clients, utility libraries, UI component libraries) and shared components. Traditional approaches have the following issues:
 
@@ -20,11 +20,11 @@ In micro-frontend architectures, multiple independent applications often need to
 - **Memory Waste**: Multiple instances of the same library exist in the browser, occupying additional memory
 - **Cache Invalidation**: Different bundled versions of the same library cannot share browser cache
 
-Module Link solves these problems through the ECMAScript module system and Import Maps specification, enabling multiple applications to safely and efficiently share code modules.
+Module Linking solves these problems through the ECMAScript module system and Import Maps specification, enabling multiple applications to safely and efficiently share code modules.
 
 ## How It Works
 
-Module Link is based on technology standards natively supported by modern browsers:
+Module Linking is based on technology standards natively supported by modern browsers:
 
 ### Shared Module Provider
 
@@ -95,7 +95,7 @@ export async function fetchOrders() {
 
 ## Configuration Guide
 
-Module Link configuration is located in the `modules` field of the `entry.node.ts` file, containing three core configuration items:
+Module Linking configuration is located in the `modules` field of the `entry.node.ts` file, containing three core configuration items:
 
 ### Basic Configuration
 
@@ -257,43 +257,43 @@ exports: {
 
 ## Best Practices
 
-### Applicable Scenarios
+### Use Case Evaluation
 
-**Suitable for**:
+**Suitable Cases**:
 - Multiple applications using the same third-party libraries (axios, lodash, moment, etc.)
 - Need to share business component libraries or utility functions
 - Want to reduce application size and improve loading performance
 - Need to ensure library version consistency across multiple applications
 
-**Not suitable for**:
-- Single application projects (no sharing requirements)
+**Not Suitable Cases**:
+- Single application projects (no sharing needs)
 - Frequently changing experimental code
 - Scenarios requiring extremely low coupling between applications
 
-### Import Standards
+### Import Guidelines
 
-**Third-party library imports**:
+**Third-party Library Imports**:
 ```typescript
-// ✅ Recommended - Use standard library names, conform to ecosystem standards
+// ✅ Recommended - Use standard library names, conforming to ecosystem standards
 import axios from 'axios';
 import { debounce } from 'lodash';
 
-// ❌ Not recommended - Violates module ecosystem standards, not conducive to library replacement and maintenance
+// ❌ Not Recommended - Violates module ecosystem standards, not conducive to library replacement and maintenance
 import axios from 'shared-lib/axios';
 ```
 
-**Custom module imports**:
+**Custom Module Imports**:
 ```typescript
-// ✅ Recommended - Directly use module link paths, clear dependency source
+// ✅ Recommended - Directly use module linking paths, clearly indicating dependency source
 import { formatDate } from 'shared-lib/src/utils/date-utils';
 
-// ❌ Invalid configuration - imports does not support path prefix functionality
+// ❌ Invalid Configuration - imports does not support path prefix functionality
 imports: { 'components': 'shared-lib/src/components' }
 import Chart from 'components/Chart';  // This import cannot be resolved
 ```
 
 ### Configuration Principles
 
-1. **Third-party libraries**: Must configure `imports` mapping, use standard names for imports
-2. **Custom modules**: Directly use complete module link paths
-3. **imports purpose**: Only used for third-party library standard name mapping, not directory aliases
+1. **Third-party Libraries**: Must configure `imports` mapping, use standard names for importing
+2. **Custom Modules**: Directly use complete module linking paths
+3. **imports Purpose**: Only for third-party library standard name mapping, not directory aliases 

--- a/examples/docs/src/en/guide/start/introduction.md
+++ b/examples/docs/src/en/guide/start/introduction.md
@@ -16,7 +16,7 @@ A micro-frontend framework based on ECMAScript Modules (ESM), designed for build
 **Technical Evolution:**
 - **v1.0**: On-demand component loading via HTTP requests
 - **v2.0**: Application integration using Webpack Module Federation
-- **v3.0**: [Module linking](/guide/essentials/module-link) system based on native browser ESM
+- **v3.0**: [Module linking](/guide/essentials/module-linking) system based on native browser ESM
 
 ## Problems Solved
 

--- a/examples/docs/src/en/index.md
+++ b/examples/docs/src/en/index.md
@@ -9,7 +9,7 @@ head:
 hero:
   name: Esmx
   text: ESM-based Server-Side Rendering Framework
-  tagline: High-performance, scalable module linking system
+  tagline: High-performance, scalable Module Linking system
   actions:
     - theme: brand
       text: Get Started

--- a/examples/docs/src/zh/guide/essentials/_meta.json
+++ b/examples/docs/src/zh/guide/essentials/_meta.json
@@ -5,5 +5,5 @@
     "csr",
     "alias",
     "base-path",
-    "module-link"
+    "module-linking"
 ]

--- a/examples/docs/src/zh/guide/essentials/alias.md
+++ b/examples/docs/src/zh/guide/essentials/alias.md
@@ -100,7 +100,7 @@ import type { UserInfo } from 'your-app-name/src/types';
 
 ### 跨服务导入
 
-当配置了模块链接（Module Link）后，可以使用相同的方式导入其他服务的模块：
+当配置了模块链接后，可以使用相同的方式导入其他服务的模块：
 
 ```ts
 // 导入远程服务的组件

--- a/examples/docs/src/zh/guide/essentials/module-linking.md
+++ b/examples/docs/src/zh/guide/essentials/module-linking.md
@@ -4,12 +4,12 @@ description: Esmx 模块链接：基于 ESM 标准的零运行时微前端代码
 head:
   - - meta
     - property: keywords
-      content: Esmx, 模块链接, Module Link, ESM, 代码共享, 微前端
+      content: Esmx, 模块链接, Module Linking, ESM, 代码共享, 微前端
 ---
 
 # 模块链接
 
-模块链接（Module Link）是 Esmx 提供的跨应用代码共享机制，基于 ECMAScript 模块标准，实现无运行时开销的微前端架构。
+模块链接（Module Linking）是 Esmx 提供的跨应用代码共享机制，基于 ECMAScript 模块标准，实现无运行时开销的微前端架构。
 
 ## 为什么需要模块链接？
 
@@ -298,13 +298,4 @@ import Chart from 'components/Chart';  // 此导入无法解析
 
 1. **第三方库**：必须配置 `imports` 映射，使用标准名称导入
 2. **自定义模块**：直接使用完整模块链接路径
-3. **imports用途**：仅用于第三方库标准名称映射，不是目录别名
-
-
-
-
-
-
-
-
-
+3. **imports用途**：仅用于第三方库标准名称映射，不是目录别名 

--- a/examples/docs/src/zh/guide/start/glossary.md
+++ b/examples/docs/src/zh/guide/start/glossary.md
@@ -4,7 +4,7 @@ description: Esmx 框架核心术语解释，帮助开发者理解模块链接�
 head:
   - - meta
     - name: keywords
-      content: Esmx, 术语表, 模块链接, 微前端, ESM, import map
+      content: Esmx, 术语表, 模块链接（Module Linking）, 微前端, ESM, import map
 ---
 
 # 术语表

--- a/examples/docs/src/zh/guide/start/introduction.md
+++ b/examples/docs/src/zh/guide/start/introduction.md
@@ -16,7 +16,7 @@ head:
 **技术演进：**
 - **v1.0**：HTTP 请求实现组件按需加载
 - **v2.0**：Webpack Module Federation 实现应用集成
-- **v3.0**：浏览器原生 ESM 的[模块链接](/guide/essentials/module-link)系统
+- **v3.0**：浏览器原生 ESM 的[模块链接](/guide/essentials/module-linking)系统
 
 ## 解决的问题
 

--- a/examples/ssr-html/src/views/about.ts
+++ b/examples/ssr-html/src/views/about.ts
@@ -29,7 +29,7 @@ export default class Home extends Page {
                         <div class="icon">🔄</div>
                         <div class="content">
                             <h3>模块共享</h3>
-                            <p>创新的 Module Link 技术，实现多个微前端应用间无缝共享和按需加载模块，降低重复依赖。</p>
+                            <p>创新的模块链接技术，实现多个微前端应用间无缝共享和按需加载模块，降低重复依赖。</p>
                         </div>
                     </div>
 

--- a/examples/ssr-vue2-host/README.md
+++ b/examples/ssr-vue2-host/README.md
@@ -1,11 +1,11 @@
 # Esmx SSR Vue2 Host
 
-一个基于 Vue2 的微前端 Host 应用示例，展示了如何使用 Esmx 构建现代化的服务端渲染应用，并通过 Module Link 集成 Remote 应用。
+一个基于 Vue2 的微前端 Host 应用示例，展示了如何使用 Esmx 构建现代化的服务端渲染应用，并通过 Module Linking 集成 Remote 应用。
 
 ## 特点
 
 - 🚀 **高性能** - 基于 Rust 构建的 Rspack，提供极致的构建性能
-- 💡 **微前端架构** - 使用 Module Link 实现应用解耦和独立部署
+- 💡 **微前端架构** - 使用 Module Linking 实现应用解耦和独立部署
 - 🛠 **开发体验** - 快速的热更新、友好的错误提示和完整的类型支持
 - 📱 **SSR支持** - 完整的服务端渲染支持，提供更好的首屏体验和SEO
 

--- a/examples/ssr-vue2-host/src/app.vue
+++ b/examples/ssr-vue2-host/src/app.vue
@@ -3,8 +3,8 @@
     <app-nav current="host" />
     
     <ui-module-header
-      title="Esmx Module Link Host"
-      description="这是一个基于 Module Link 的宿主应用示例，演示了如何在 SSR 环境下集成和使用远程模块。通过 Module Link 的依赖共享机制，可以确保宿主应用和远程模块使用相同版本的 Vue 实例，有效避免运行时冲突。"
+      title="Esmx Module Linking Host"
+      description="这是一个基于 Module Linking 的宿主应用示例，演示了如何在 SSR 环境下集成和使用远程模块。通过 Module Linking 的依赖共享机制，可以确保宿主应用和远程模块使用相同版本的 Vue 实例，有效避免运行时冲突。"
     />
 
     <main class="app-main">

--- a/examples/ssr-vue2-host/src/entry.server.ts
+++ b/examples/ssr-vue2-host/src/entry.server.ts
@@ -20,7 +20,7 @@ export default async (rc: RenderContext) => {
     ${rc.preload()}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Esmx Module Link Host</title>
+    <title>Esmx Module Linking Host</title>
     <link rel="icon" type="image/svg+xml" href="https://www.esmnext.com/logo.svg">
     ${rc.css()}
 </head>

--- a/examples/ssr-vue2-remote/README.md
+++ b/examples/ssr-vue2-remote/README.md
@@ -5,7 +5,7 @@
 ## 特点
 
 - 🚀 **高性能**   - 基于 Rust 构建的 Rspack，提供极致的构建性能
-- 💡 **模块输出** - 支持 Module Link，可被其他应用无缝集成
+- 💡 **模块输出** - 支持 Module Linking，可被其他应用无缝集成
 - 🛠 **开发体验** - 快速的热更新、友好的错误提示和完整的类型支持
 - 📱 **SSR支持** - 完整的服务端渲染支持，确保与 Host 应用的 SSR 能力对接
 
@@ -42,7 +42,7 @@ src/
 ├── assets/                 # 静态资源
 ├── entry-client.ts         # 客户端入口
 ├── entry-server.ts         # 服务端入口
-├── expose.ts               # Module Link 导出配置
+├── entry.node.ts           # Module Linking 导出配置
 └── App.vue                 # 根组件
 ```
 

--- a/examples/ssr-vue2-remote/src/app.vue
+++ b/examples/ssr-vue2-remote/src/app.vue
@@ -3,8 +3,8 @@
     <app-nav current="remote" />
     
     <ui-module-header
-      title="Esmx Module Link Remote"
-      description="这是一个 Module Link 远程模块示例，用于展示可复用的组件。通过 Module Link，你可以轻松地在不同项目间共享和复用组件，实现真正的模块化开发。"
+      title="Esmx Module Linking Remote"
+      description="这是一个 Module Linking 远程模块示例，用于展示可复用的组件。通过 Module Linking，你可以轻松地在不同项目间共享和复用组件，实现真正的模块化开发。"
     />
 
     <main class="app-main">

--- a/examples/ssr-vue2-remote/src/entry.server.ts
+++ b/examples/ssr-vue2-remote/src/entry.server.ts
@@ -20,7 +20,7 @@ export default async (rc: RenderContext) => {
     ${rc.preload()}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Esmx Module Link Remote</title>
+    <title>Esmx Module Linking Remote</title>
     <link rel="icon" type="image/svg+xml" href="https://www.esmnext.com/logo.svg">
     ${rc.css()}
 </head>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,7 +33,7 @@
 - **Dependency Management** - Centralized dependency management with content-hash-based strong caching strategy
 - **Application Isolation** - ESM native module isolation ensuring runtime stability
 - **SSR Support** - Flexible server-side rendering strategy supporting any frontend framework
-- **Developer Experience** - Complete TypeScript support with native module linking capabilities
+- **Developer Experience** - Complete TypeScript support with native Module Linking capabilities
 
 ## 📦 Installation
 

--- a/packages/core/src/module-config.ts
+++ b/packages/core/src/module-config.ts
@@ -7,7 +7,7 @@ import type { BuildSsrTarget } from './core';
  */
 export interface ModuleConfig {
     /**
-     * Module link configuration.
+     * Module linking configuration.
      * Key is remote module name, value is module build output directory path.
      *
      * @example
@@ -207,7 +207,7 @@ const PREFIX = {
 } as const;
 
 /**
- * Process and resolve module links configuration.
+ * Process and resolve module linking configuration.
  * Creates absolute paths for client/server directories and manifest files.
  * Automatically includes the current module as a self-link.
  *

--- a/packages/rspack-module-link-plugin/README.md
+++ b/packages/rspack-module-link-plugin/README.md
@@ -20,7 +20,7 @@
     </a>
   </div>
   
-  <p>Rspack plugin for advanced module linking and federation capabilities in Esmx framework</p>
+  <p>Rspack plugin for advanced Module Linking and federation capabilities in Esmx framework</p>
   
   <p>
     English | <a href="https://github.com/esmnext/esmx/blob/master/packages/rspack-module-link-plugin/README.zh-CN.md">中文</a>
@@ -30,7 +30,7 @@
 ## 🚀 Features
 
 - **Module Federation** - Advanced module federation capabilities for microfrontend architecture
-- **Dynamic Linking** - Runtime module linking and resolution
+- **Dynamic Linking** - Runtime Module Linking and resolution
 - **Performance Optimized** - Optimized for production use with minimal overhead
 - **TypeScript Support** - Full TypeScript support with type safety
 - **Hot Reloading** - Supports hot module replacement during development


### PR DESCRIPTION
**Feature Description:**
Unify terminology across framework documentation and examples by updating "Module Link" to "Module Linking".

**Implementation Details:**
- Renamed module-link.md files to module-linking.md in both English and Chinese documentation
- Updated corresponding entries in navigation config files (_meta.json)
- Corrected terminology usage in documentation and example code
- Maintained consistency of "模块链接" in Chinese documentation, with English terms only where necessary (e.g., glossary)
- Fixed incorrect file references in example projects (expose.ts → entry.node.ts)

**Testing:**
Verified link correctness and content consistency through local documentation builds.

**Potential Impact:**
This change only affects terminology in documentation and examples, with no impact on code functionality or APIs. Package names (such as rspack-module-link-plugin) remain unchanged to avoid breaking changes.

**Additional Notes:**
This update aims to maintain consistent terminology, making it easier for developers and users to understand framework concepts.