### PR TITLE
fix(create-esmx): add dedicated CLI entry point for npm create command

### DIFF
--- a/packages/create-esmx/package.json
+++ b/packages/create-esmx/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "private": false,
     "bin": {
-        "create-esmx": "./dist/index.mjs"
+        "create-esmx": "./dist/cli.mjs"
     },
     "template": "library-node",
     "scripts": {

--- a/packages/create-esmx/src/cli.ts
+++ b/packages/create-esmx/src/cli.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { createProject } from './index';
+
+createProject().catch((error) => {
+    console.error('Error creating project:', error);
+    process.exit(1);
+});

--- a/packages/create-esmx/src/index.ts
+++ b/packages/create-esmx/src/index.ts
@@ -382,10 +382,3 @@ function copyTemplateFiles(
 }
 
 export default createProject;
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-    createProject().catch((error) => {
-        console.error('Error creating project:', error);
-        process.exit(1);
-    });
-}


### PR DESCRIPTION
## Issue Fixed

Added a dedicated CLI entry point to fix the issue where the `npm create esmx@latest` command was not executing properly.

## Changes Made

- Created a dedicated `src/cli.ts` file as the CLI entry point that directly executes the `createProject()` function
- Modified the `bin` configuration in `package.json` to point to the new `dist/cli.mjs` file
- Removed the conditional logic from `index.ts` (`import.meta.url === file://${process.argv[1]}`), which might not be satisfied in the `npm create` command execution environment

## Technical Decision

Chose to create a dedicated CLI entry point file instead of modifying the conditional logic for the following reasons:
1. Provides a clearer and more reliable execution path
2. Adheres to the principle of separation of concerns
3. The dedicated CLI file handles command execution, while the core module focuses on exporting functionality

## Testing

- All existing test cases have been run to ensure the changes do not break existing functionality
- Test results: All tests passed