### PR TITLE
fix(rspack): fix hot reload path matching issue

### DIFF
--- a/packages/rspack/src/hot-fix.ts
+++ b/packages/rspack/src/hot-fix.ts
@@ -30,7 +30,7 @@
     });
     function isSameModule(hotUrl: string, originalUrl: string): boolean {
         const normalizedHotUrl = hotUrl
-            .replace(/\/__hot__\//, '/')
+            .replace(/\/__hot__\//, '/exports/')
             .replace(/\.\w+\.hot-update\.mjs$/, '.mjs');
         const normalizedOriginalUrl = originalUrl;
         return normalizedHotUrl === normalizedOriginalUrl;


### PR DESCRIPTION
**Problem Description:**
When output files are configured in the exports/ directory, hot reload functionality fails. This occurs because the path replacement logic in the hot reload mechanism does not account for the directory structure of the output files.

**Fix Method:**
Modified the path replacement logic in hot-fix.ts from `replace(/\/__hot__\//, '/')` to `replace(/\/__hot__\//, '/exports/')`, enabling hot reload paths to correctly map to source files in the exports/ directory.

**Testing Method:**
Verified hot reload functionality works correctly in the local development environment.

**Impact Range:**
Only affects hot reload functionality in development environment, with no impact on production.