### PR TITLE
fix(rspack-vue): rename vue-loader packages to fix detection in bun

### DIFF
--- a/packages/rspack-vue/package.json
+++ b/packages/rspack-vue/package.json
@@ -58,8 +58,8 @@
     "dependencies": {
         "@esmx/rspack": "workspace:*",
         "vue-style-loader": "^4.1.3",
-        "vue2-loader": "npm:vue-loader@15.11.1",
-        "vue3-loader": "npm:vue-loader@^17.4.2"
+        "vue-loader-v15": "npm:vue-loader@15.11.1",
+        "vue-loader-v17": "npm:vue-loader@^17.4.2"
     },
     "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/packages/rspack-vue/src/vue-core.ts
+++ b/packages/rspack-vue/src/vue-core.ts
@@ -1,7 +1,7 @@
 import type { Esmx } from '@esmx/core';
 import { createRspackHtmlApp, rspack } from '@esmx/rspack';
-import { VueLoaderPlugin as VueLoader2Plugin } from 'vue2-loader';
-import { VueLoaderPlugin as VueLoader3Plugin } from 'vue3-loader';
+import { VueLoaderPlugin as VueLoader2Plugin } from 'vue-loader-v15';
+import { VueLoaderPlugin as VueLoader3Plugin } from 'vue-loader-v17';
 import type { RspackVueAppOptions } from './vue';
 import { vue2Loader } from './vue2-loader';
 import { vue3Loader } from './vue3-loader';
@@ -48,8 +48,11 @@ export function createRspackVueApp(
             // 设置 vue-loader
             const vueRuleUse: rspack.RuleSetUse = [
                 {
-                    loader: new URL(import.meta.resolve(`vue${vueType}-loader`))
-                        .pathname,
+                    loader: new URL(
+                        import.meta.resolve(
+                            `vue-loader-v${vueType === '2' ? '15' : '17'}`
+                        )
+                    ).pathname,
                     options: {
                         ...options?.vueLoader,
                         experimentalInlineMatchResource: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,15 +950,15 @@ importers:
       vue:
         specifier: '>=2.7.8 || >=3.0.0'
         version: 3.5.17(typescript@5.8.3)
+      vue-loader-v15:
+        specifier: npm:vue-loader@15.11.1
+        version: vue-loader@15.11.1(@vue/compiler-sfc@3.5.17)(css-loader@7.1.2(@rspack/core@1.4.6(@swc/helpers@0.5.17))(webpack@5.99.9))(webpack@5.99.9)
+      vue-loader-v17:
+        specifier: npm:vue-loader@^17.4.2
+        version: vue-loader@17.4.2(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))(webpack@5.99.9)
       vue-style-loader:
         specifier: ^4.1.3
         version: 4.1.3
-      vue2-loader:
-        specifier: npm:vue-loader@15.11.1
-        version: vue-loader@15.11.1(@vue/compiler-sfc@3.5.17)(css-loader@7.1.2(@rspack/core@1.4.6(@swc/helpers@0.5.17))(webpack@5.99.9))(webpack@5.99.9)
-      vue3-loader:
-        specifier: npm:vue-loader@^17.4.2
-        version: vue-loader@17.4.2(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))(webpack@5.99.9)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4


### PR DESCRIPTION
**Issue Description:**
In the bun environment, vue-loader uses a regular expression `/^vue-loader|(\/|\|@)vue-loader/` to detect loaders. However, our aliases `vue2-loader` and `vue3-loader` don't match this pattern, causing vue-loader detection to fail in bun.

**Fix:**
Modified dependency aliases in package.json to include "vue-loader" in the name:
1. Changed `vue2-loader` to `vue-loader-v15`
2. Changed `vue3-loader` to `vue-loader-v17`

Also updated related import statements and references in the code.

**Scope of Impact:**
This fix only affects the @esmx/rspack-vue package and doesn't impact other functionality. After the fix, vue-loader will be correctly detected in the bun environment.

**Testing Method:**
Build a Vue application with @esmx/rspack-vue in the bun environment and verify that no vue-loader detection errors occur.