### PR TITLE
fix(scripts): standardize start scripts across all packages

### DIFF
--- a/examples/router-demo/ssr-npm-base/package.json
+++ b/examples/router-demo/ssr-npm-base/package.json
@@ -4,7 +4,8 @@
     "type": "module",
     "private": true,
     "scripts": {
-        "build": "esmx build"
+        "build": "esmx build",
+        "start": "NODE_ENV=production node dist/index.mjs"
     },
     "dependencies": {
         "@esmx/core": "workspace:*"

--- a/examples/router-demo/ssr-npm-vue2/package.json
+++ b/examples/router-demo/ssr-npm-vue2/package.json
@@ -4,7 +4,8 @@
     "type": "module",
     "private": true,
     "scripts": {
-        "build": "esmx build"
+        "build": "esmx build",
+        "start": "NODE_ENV=production node dist/index.mjs"
     },
     "dependencies": {
         "@esmx/core": "workspace:*"

--- a/examples/router-demo/ssr-npm-vue3/package.json
+++ b/examples/router-demo/ssr-npm-vue3/package.json
@@ -4,7 +4,8 @@
     "type": "module",
     "private": true,
     "scripts": {
-        "build": "esmx build"
+        "build": "esmx build",
+        "start": "NODE_ENV=production node dist/index.mjs"
     },
     "dependencies": {
         "@esmx/core": "workspace:*"

--- a/examples/router-demo/ssr-share/package.json
+++ b/examples/router-demo/ssr-share/package.json
@@ -4,7 +4,8 @@
     "type": "module",
     "private": true,
     "scripts": {
-        "build": "esmx build"
+        "build": "esmx build",
+        "start": "NODE_ENV=production node dist/index.mjs"
     },
     "dependencies": {
         "@esmx/core": "workspace:*"

--- a/packages/create-esmx/src/utils/template.test.ts
+++ b/packages/create-esmx/src/utils/template.test.ts
@@ -170,7 +170,7 @@ Esmx version: {{esmxVersion}}`;
   "scripts": {
     "dev": "esmx dev",
     "build": "esmx build",
-    "start": "esmx start"
+    "start": "NODE_ENV=production node dist/index.mjs"
   },
   "dependencies": {
     "esmx": "{{esmxVersion}}"

--- a/packages/create-esmx/template/vue2/package.json
+++ b/packages/create-esmx/template/vue2/package.json
@@ -8,7 +8,7 @@
         "dev": "esmx dev",
         "build": "esmx build",
         "preview": "esmx preview",
-        "start": "esmx start",
+        "start": "NODE_ENV=production node dist/index.mjs",
         "lint:type": "vue-tsc --noEmit",
         "build:type": "vue-tsc --declaration --emitDeclarationOnly --noEmit false --outDir dist/src && tsc-alias -p tsconfig.json --outDir dist/src"
     },


### PR DESCRIPTION
**Feature Description:**
Standardize start scripts across all packages and example projects, ensuring they all use the same format "start": "NODE_ENV=production node dist/index.mjs".

**Implementation Details:**
- Added standard start command to 4 packages that were missing it
- Modified non-standard start command in Vue2 template package
- Updated example code in related test files
- Ensured all packages and example projects use the same start command format

**Testing:**
Verified all modifications through code review and Git diff.

**Potential Impact:**
This change affects project template generation and how example projects are started, making them consistent with other projects.