### PR TITLE
feat(router): re-export deprecated types and properties for backward compatibility

### DIFF
--- a/examples/router-demo-vue2/src/create-app.ts
+++ b/examples/router-demo-vue2/src/create-app.ts
@@ -3,7 +3,7 @@
  * @description 负责创建和配置 Vue 应用实例
  */
 
-import { Router } from '@esmx/router';
+import { Router, RouterInstance } from '@esmx/router';
 import { RouterPlugin, RouterView, useProvideRouter } from '@esmx/router-vue';
 import Vue from 'vue';
 import { routes } from './routes';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -49,3 +49,21 @@ export {
     RouteNavigationAbortedError,
     RouteSelfRedirectionError
 } from './error';
+
+// =================== Re-exporting deprecated types ===================
+
+// Cannot propagate deprecated JSDoc when re-export due to TypeScript bug: https://github.com/microsoft/TypeScript/issues/53960
+// export type {
+//     /** @deprecated Use `Router` directly instead of `RouterInstance`. */
+//     Router as RouterInstance
+// } from './router';
+
+import type { Router } from './router';
+/** @deprecated Use `Router` directly instead of `RouterInstance`. */
+export type RouterInstance = Router;
+
+import type { Route, RouteLocationInput } from './types';
+/** @deprecated Use `RouteLocationInput` directly instead of `RouterRawLocation`. */
+export type RouterRawLocation = RouteLocationInput;
+/** @deprecated Use `Route` directly instead of `RouterLocation`. */
+export type RouterLocation = Route;

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -127,6 +127,16 @@ export class Route {
     public readonly matched: readonly RouteParsedConfig[];
     public readonly config: RouteParsedConfig | null;
 
+    /** @deprecated Use `url.pathname` instead. */
+    public get pathname(): string {
+        return this.url.pathname;
+    }
+
+    /** @deprecated Use `url.href` instead. */
+    public get href(): string {
+        return this.url.href;
+    }
+
     constructor(routeOptions: Partial<RouteOptions> = {}) {
         const {
             toType = RouteType.push,


### PR DESCRIPTION
Re-export deprecated types and properties:

- `RouterInstance` = `Router`
- `RouterRawLocation` = `RouteLocationInput`
- `RouterLocation` = `Route`
- `Route.pathname` = `Route.url.pathname`
- `Route.href` = `Route.url.href`
