### PR TITLE
feat: clean Chinese comments in rspack package

### DIFF
--- a/packages/rspack/src/rspack-html/index.ts
+++ b/packages/rspack/src/rspack-html/index.ts
@@ -15,41 +15,41 @@ import {
 
 export interface RspackHtmlAppOptions extends RspackAppOptions {
     /**
-     * CSS 输出模式配置
+     * CSS output mode configuration
      *
-     * @default 根据环境自动选择：
-     * - 生产环境: 'css'，将CSS输出到独立文件中，有利于缓存和并行加载
-     * - 开发环境: 'js'，将CSS打包到JS中以支持热更新(HMR)，实现样式的即时更新
+     * @default Automatically selected based on environment:
+     * - Production: 'css', outputs CSS to separate files for better caching and parallel loading
+     * - Development: 'js', bundles CSS into JS to support hot module replacement (HMR) for instant style updates
      *
-     * - 'css': 将 CSS 输出到独立的 CSS 文件中
-     * - 'js': 将 CSS 打包到 JS 文件中，运行时动态插入样式
-     * - false: 关闭默认的 CSS 处理配置，需要手动配置 loader 规则
+     * - 'css': Output CSS to separate CSS files
+     * - 'js': Bundle CSS into JS files and dynamically inject styles at runtime
+     * - false: Disable default CSS processing configuration, requires manual loader rule configuration
      *
      * @example
      * ```ts
-     * // 使用环境默认配置
+     * // Use environment default configuration
      * css: undefined
      *
-     * // 强制输出到独立的 CSS 文件
+     * // Force output to separate CSS files
      * css: 'css'
      *
-     * // 强制打包到 JS 中
+     * // Force bundle into JS
      * css: 'js'
      *
-     * // 自定义 CSS 处理
+     * // Custom CSS processing
      * css: false
      * ```
      */
     css?: 'css' | 'js' | false;
 
     /**
-     * 自定义 loader 配置
+     * Custom loader configuration
      *
-     * 允许替换默认的 loader 实现，可用于切换到特定框架的 loader
+     * Allows replacing default loader implementations, useful for switching to framework-specific loaders
      *
      * @example
      * ```ts
-     * // 使用 Vue 的 style-loader
+     * // Use Vue's style-loader
      * loaders: {
      *   styleLoader: 'vue-style-loader'
      * }
@@ -58,9 +58,7 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     loaders?: Partial<Record<keyof typeof RSPACK_LOADER, string>>;
 
     /**
-     * style-loader 配置项
-     *
-     * 用于配置样式注入方式，完整选项参考:
+     * Configure style injection method. For complete options, see:
      * https://github.com/webpack-contrib/style-loader
      *
      * @example
@@ -74,9 +72,7 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     styleLoader?: Record<string, any>;
 
     /**
-     * css-loader 配置项
-     *
-     * 用于配置 CSS 模块化、URL 解析等，完整选项参考:
+     * Configure CSS modules, URL resolution, etc. For complete options, see:
      * https://github.com/webpack-contrib/css-loader
      *
      * @example
@@ -90,9 +86,7 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     cssLoader?: Record<string, any>;
 
     /**
-     * less-loader 配置项
-     *
-     * 用于配置 Less 编译选项，完整选项参考:
+     * Configure Less compilation options. For complete options, see:
      * https://github.com/webpack-contrib/less-loader
      *
      * @example
@@ -108,9 +102,7 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     lessLoader?: Record<string, any>;
 
     /**
-     * style-resources-loader 配置项
-     *
-     * 用于自动注入全局的样式资源，完整选项参考:
+     * Automatically inject global style resources. For complete options, see:
      * https://github.com/yenshih/style-resources-loader
      *
      * @example
@@ -126,9 +118,7 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     styleResourcesLoader?: Record<string, any>;
 
     /**
-     * SWC loader 配置项
-     *
-     * 用于配置 TypeScript/JavaScript 编译选项，完整选项参考:
+     * Configure TypeScript/JavaScript compilation options. For complete options, see:
      * https://rspack.dev/guide/features/builtin-swc-loader
      *
      * @example
@@ -149,19 +139,17 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     swcLoader?: SwcLoaderOptions;
 
     /**
-     * DefinePlugin 配置项
-     *
-     * 用于定义编译时的全局常量，支持针对不同构建目标设置不同的值
-     * 完整说明参考: https://rspack.dev/plugins/webpack/define-plugin
+     * Define compile-time global constants, supports setting different values for different build targets
+     * For complete documentation, see: https://rspack.dev/plugins/webpack/define-plugin
      *
      * @example
      * ```ts
-     * // 统一的值
+     * // Unified value
      * definePlugin: {
      *   'process.env.APP_ENV': JSON.stringify('production')
      * }
      *
-     * // 针对不同构建目标的值
+     * // Values for different build targets
      * definePlugin: {
      *   'process.env.IS_SERVER': {
      *     server: 'true',
@@ -176,31 +164,25 @@ export interface RspackHtmlAppOptions extends RspackAppOptions {
     >;
 
     /**
-     * 构建目标配置
-     *
-     * 用于设置代码的目标运行环境，影响代码的编译降级和 polyfill 注入
+     * Set the target runtime environment for the code, affecting code compilation downgrading and polyfill injection
      *
      * @example
      * ```ts
      * target: {
-     *   // 浏览器构建目标
+     *   // Browser build targets
      *   web: ['chrome>=87', 'firefox>=78', 'safari>=14'],
-     *   // Node.js 构建目标
+     *   // Node.js build targets
      *   node: ['node>=16']
      * }
      * ```
      */
     target?: {
         /**
-         * 浏览器构建目标
-         *
          * @default ['chrome>=64', 'edge>=79', 'firefox>=67', 'safari>=11.1']
          */
         web?: string[];
 
         /**
-         * Node.js 构建目标
-         *
          * @default ['node>=24']
          */
         node?: string[];

--- a/packages/rspack/src/rspack/app.ts
+++ b/packages/rspack/src/rspack/app.ts
@@ -26,13 +26,13 @@ const hotFixCode = fs.readFileSync(
 );
 
 /**
- * Rspack 应用配置上下文接口。
+ * Rspack application configuration context interface.
  *
- * 该接口提供了在配置钩子函数中可以访问的上下文信息，允许你：
- * - 访问 Esmx 框架实例
- * - 获取当前的构建目标（client/server/node）
- * - 修改 Rspack 配置
- * - 访问应用选项
+ * This interface provides context information accessible in configuration hook functions, allowing you to:
+ * - Access the Esmx framework instance
+ * - Get the current build target (client/server/node)
+ * - Modify Rspack configuration
+ * - Access application options
  *
  * @example
  * ```ts
@@ -41,11 +41,11 @@ const hotFixCode = fs.readFileSync(
  *   async devApp(esmx) {
  *     return import('@esmx/rspack').then((m) =>
  *       m.createRspackApp(esmx, {
- *         // 配置钩子函数
+ *         // Configuration hook function
  *         config(context) {
- *           // 访问构建目标
+ *           // Access build target
  *           if (context.buildTarget === 'client') {
- *             // 修改客户端构建配置
+ *             // Modify client build configuration
  *             context.config.optimization = {
  *               ...context.config.optimization,
  *               splitChunks: {
@@ -62,73 +62,73 @@ const hotFixCode = fs.readFileSync(
  */
 export interface RspackAppConfigContext {
     /**
-     * Esmx 框架实例。
-     * 可用于访问框架提供的 API 和工具函数。
+     * Esmx framework instance.
+     * Can be used to access framework APIs and utility functions.
      */
     esmx: Esmx;
 
     /**
-     * 当前的构建目标。
-     * - 'client': 客户端构建，生成浏览器可执行的代码
-     * - 'server': 服务端构建，生成 SSR 渲染代码
-     * - 'node': Node.js 构建，生成服务器入口代码
+     * Current build target.
+     * - 'client': Client build, generates browser-executable code
+     * - 'server': Server build, generates SSR rendering code
+     * - 'node': Node.js build, generates server entry code
      */
     buildTarget: BuildTarget;
 
     /**
-     * Rspack 编译配置对象。
-     * 你可以在配置钩子中修改这个对象来自定义构建行为。
+     * Rspack compilation configuration object.
+     * You can modify this object in configuration hooks to customize build behavior.
      */
     config: RspackOptions;
 
     /**
-     * 创建应用时传入的选项对象。
+     * Options object passed when creating the application.
      */
     options: RspackAppOptions;
 }
 
 /**
- * Rspack 链式配置上下文接口。
+ * Rspack chain configuration context interface.
  *
- * 该接口提供了在 chain 钩子函数中可以访问的上下文信息，允许你：
- * - 访问 Esmx 框架实例
- * - 获取当前的构建目标（client/server/node）
- * - 使用 rspack-chain 修改配置
- * - 访问应用选项
+ * This interface provides context information accessible in chain hook functions, allowing you to:
+ * - Access the Esmx framework instance
+ * - Get the current build target (client/server/node)
+ * - Modify configuration using rspack-chain
+ * - Access application options
  */
 export interface RspackAppChainContext {
     /**
-     * Esmx 框架实例。
-     * 可用于访问框架提供的 API 和工具函数。
+     * Esmx framework instance.
+     * Can be used to access framework APIs and utility functions.
      */
     esmx: Esmx;
 
     /**
-     * 当前的构建目标。
-     * - 'client': 客户端构建，生成浏览器可执行的代码
-     * - 'server': 服务端构建，生成 SSR 渲染代码
-     * - 'node': Node.js 构建，生成服务器入口代码
+     * Current build target.
+     * - 'client': Client build, generates browser-executable code
+     * - 'server': Server build, generates SSR rendering code
+     * - 'node': Node.js build, generates server entry code
      */
     buildTarget: BuildTarget;
 
     /**
-     * rspack-chain 配置对象。
-     * 你可以在 chain 钩子中使用链式 API 修改配置。
+     * rspack-chain configuration object.
+     * You can use the chain API in chain hooks to modify the configuration.
      */
     chain: import('rspack-chain');
 
     /**
-     * 创建应用时传入的选项对象。
+     * Options object passed when creating the application.
      */
     options: RspackAppOptions;
 }
 
 /**
- * Rspack 应用配置选项接口。
+ * Rspack application configuration options interface.
  *
- * 该接口提供了创建 Rspack 应用时可以使用的配置选项，包括：
- * - 代码压缩选项
- * - Rspack 配置钩子函数
+ * This interface provides configuration options available when creating a Rspack application, including:
+ * - Code compression options
+ * - Rspack configuration hook functions
  *
  * @example
  * ```ts
@@ -137,9 +137,9 @@ export interface RspackAppChainContext {
  *   async devApp(esmx) {
  *     return import('@esmx/rspack').then((m) =>
  *       m.createRspackApp(esmx, {
- *         // 禁用代码压缩
+ *         // Disable code compression
  *         minimize: false,
- *         // 自定义 Rspack 配置
+ *         // Custom Rspack configuration
  *         config(context) {
  *           if (context.buildTarget === 'client') {
  *             context.config.optimization.splitChunks = {
@@ -155,47 +155,43 @@ export interface RspackAppChainContext {
  */
 export interface RspackAppOptions {
     /**
-     * 是否启用代码压缩。
+     * Whether to enable code compression.
      *
-     * - true: 启用代码压缩
-     * - false: 禁用代码压缩
-     * - undefined: 根据环境自动判断（生产环境启用，开发环境禁用）
+     * - true: Enable code compression
+     * - false: Disable code compression
+     * - undefined: Automatically determine based on environment (enabled in production, disabled in development)
      *
      * @default undefined
      */
     minimize?: boolean;
 
     /**
-     * Rspack 配置钩子函数。
+     * Called before the build starts, this function allows you to modify the Rspack compilation configuration.
+     * Supports differentiated configuration for different build targets (client/server/node).
      *
-     * 在构建开始前调用，可以通过该函数修改 Rspack 的编译配置。
-     * 支持针对不同的构建目标（client/server/node）进行差异化配置。
-     *
-     * @param context - 配置上下文，包含框架实例、构建目标和配置对象
+     * @param context - Configuration context, containing framework instance, build target, and configuration object
      */
     config?: (context: RspackAppConfigContext) => void;
 
     /**
-     * Rspack chain 配置钩子函数。
+     * Uses rspack-chain to provide chained configuration method, allowing more flexible modification of Rspack configuration.
+     * Called after the config hook, if chain hook exists, chained configuration is preferred.
      *
-     * 使用 rspack-chain 提供链式配置方式，可以更灵活地修改 Rspack 配置。
-     * 在 config 钩子之后调用，如果有 chain 钩子则优先使用链式配置。
-     *
-     * @param context - 配置上下文，包含框架实例、构建目标和 chain 配置对象
+     * @param context - Configuration context, containing framework instance, build target, and chain configuration object
      */
     chain?: (context: RspackAppChainContext) => void;
 }
 
 /**
- * 创建 Rspack 应用实例。
+ * Create Rspack application instance.
  *
- * 该函数根据运行环境（开发/生产）创建不同的应用实例：
- * - 开发环境：配置热更新中间件和实时渲染
- * - 生产环境：配置构建任务
+ * This function creates different application instances based on the runtime environment (development/production):
+ * - Development environment: Configures hot update middleware and real-time rendering
+ * - Production environment: Configures build tasks
  *
- * @param esmx - Esmx 框架实例
- * @param options - Rspack 应用配置选项
- * @returns 返回应用实例
+ * @param esmx - Esmx framework instance
+ * @param options - Rspack application configuration options
+ * @returns Returns application instance
  *
  * @example
  * ```ts
@@ -205,7 +201,7 @@ export interface RspackAppOptions {
  *     return import('@esmx/rspack').then((m) =>
  *       m.createRspackApp(esmx, {
  *         config(context) {
- *           // 配置 loader 处理不同类型的文件
+ *           // Configure loader to handle different file types
  *           context.config.module = {
  *             rules: [
  *               {

--- a/packages/rspack/src/rspack/config.ts
+++ b/packages/rspack/src/rspack/config.ts
@@ -13,7 +13,7 @@ import type { BuildTarget } from './build-target';
 import { HMR_DIR, HMR_JSONP } from './hmr-config';
 
 /**
- * 构建 Client、Server、Node 的基础配置
+ * Base configuration for building Client, Server, and Node targets
  */
 export function createRspackConfig(
     esmx: Esmx,
@@ -23,7 +23,7 @@ export function createRspackConfig(
     const isHot = buildTarget === 'client' && !esmx.isProd;
     return {
         /**
-         * 项目根目录，不可修改
+         * Project root directory, cannot be modified
          */
         context: esmx.root,
         output: {

--- a/packages/rspack/src/rspack/loader.ts
+++ b/packages/rspack/src/rspack/loader.ts
@@ -5,32 +5,11 @@ function resolve(name: string) {
 }
 
 export const RSPACK_LOADER = {
-    /**
-     * Rspack 内置的 builtin:swc-loader
-     */
     builtinSwcLoader: 'builtin:swc-loader',
-    /**
-     * Rspack 内置的 lightningcss-loader
-     */
     lightningcssLoader: 'builtin:lightningcss-loader',
-    /**
-     * css-loader
-     */
     cssLoader: resolve('css-loader'),
-    /**
-     * style-loader
-     */
     styleLoader: resolve('style-loader'),
-    /**
-     * less-loader
-     */
     lessLoader: resolve('less-loader'),
-    /**
-     * style-resources-loader
-     */
     styleResourcesLoader: resolve('style-resources-loader'),
-    /**
-     * worker-rspack-loader
-     */
     workerRspackLoader: resolve('worker-rspack-loader')
 } satisfies Record<string, string>;

--- a/packages/rspack/src/rspack/utils/rsbuild.ts
+++ b/packages/rspack/src/rspack/utils/rsbuild.ts
@@ -51,7 +51,7 @@ export function createRsBuild(options: RspackOptions[]) {
                 }
             });
 
-            // 监听进程信号，确保优雅退出
+            // Listen to process signals to ensure graceful shutdown
             const signals = ['SIGINT', 'SIGTERM', 'SIGHUP'] satisfies string[];
             signals.forEach((signal) => {
                 process.on(signal, () => {
@@ -61,7 +61,7 @@ export function createRsBuild(options: RspackOptions[]) {
                 });
             });
 
-            // 监听未捕获的异常和 Promise 拒绝
+            // Listen to uncaught exceptions and Promise rejections
             process.on('uncaughtException', handleExit);
             process.on('unhandledRejection', handleExit);
 


### PR DESCRIPTION
## Summary

This PR cleans up Chinese comments in the rspack package to improve international collaboration and code consistency. The changes include:

- Remove meaningless comments that just repeat property names
- Translate meaningful Chinese comments to English
- Clean up comments in rspack-html, rspack/app, rspack/config, rspack/loader, and rspack/utils/rsbuild.ts
- Improve code documentation for better maintainability

## Related links

None

## Checklist

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)