### PR TITLE
feat(rspack): enhance asset handling rules

### DIFF
--- a/packages/rspack/src/rspack-html/index.ts
+++ b/packages/rspack/src/rspack-html/index.ts
@@ -236,7 +236,9 @@ export async function createRspackHtmlApp(
 function configureAssetRules(chain: RspackChain, esmx: Esmx): void {
     chain.module
         .rule('images')
-        .test(/\.(jpe?g|png|gif|bmp|webp|svg)$/i)
+        .test(
+            /\.(png|jpg|jpeg|gif|svg|bmp|webp|ico|apng|avif|tif|tiff|jfif|pjpeg|pjp|cur)$/i
+        )
         .type('asset/resource')
         .set('generator', {
             filename: filename(esmx, 'images')
@@ -244,15 +246,23 @@ function configureAssetRules(chain: RspackChain, esmx: Esmx): void {
 
     chain.module
         .rule('media')
-        .test(/\.(mp4|webm|ogg|mp3|wav|flac|aac)$/i)
+        .test(/\.(mp4|webm|ogg|mov)$/i)
         .type('asset/resource')
         .set('generator', {
             filename: filename(esmx, 'media')
         });
 
     chain.module
+        .rule('audio')
+        .test(/\.(mp3|wav|flac|aac|m4a|opus)$/i)
+        .type('asset/resource')
+        .set('generator', {
+            filename: filename(esmx, 'audio')
+        });
+
+    chain.module
         .rule('fonts')
-        .test(/\.(woff|woff2|eot|ttf|otf)(\?.*)?$/i)
+        .test(/\.(woff|woff2|eot|ttf|otf|ttc)(\?.*)?$/i)
         .type('asset/resource')
         .set('generator', {
             filename: filename(esmx, 'fonts')


### PR DESCRIPTION
## Summary

This PR enhances the asset handling rules in the Rspack HTML configuration to provide better support for various file formats and improve asset categorization.

Key changes:
- Expand image format support to include ico, apng, avif, tif, tiff, jfif, pjpeg, pjp, cur
- Separate media and audio rules for better organization and handling
- Add mov format to media rule for video files
- Add m4a and opus formats to audio rule for better audio format support
- Include ttc format in fonts rule for TrueType Collection support
- Improve asset categorization and handling with dedicated rules

## Related links

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)