### PR TITLE
refactor: unify inputTarget to entryPoints and BuildSsrTarget to BuildEnvironment

### DIFF
--- a/examples/docs/src/en/api/core/esmx.md
+++ b/examples/docs/src/en/api/core/esmx.md
@@ -15,11 +15,11 @@ Esmx is a high-performance web application framework based on Rspack, providing 
 
 ## Type Definitions
 
-### BuildSsrTarget
+### BuildEnvironment
 
 - **Type Definition**:
 ```ts
-type BuildSsrTarget = 'client' | 'server'
+type BuildEnvironment = 'client' | 'server'
 ```
 
 Application runtime environment types:
@@ -517,7 +517,7 @@ async server(esmx) {
 Gets build manifest list.
 
 - **Parameters**:
-  - `target`: `BuildSsrTarget` - Target environment type
+  - `target`: `BuildEnvironment` - Target environment type
     - `'client'`: Client environment
     - `'server'`: Server environment
 
@@ -557,7 +557,7 @@ async server(esmx) {
 Gets import map object.
 
 - **Parameters**:
-  - `target`: `BuildSsrTarget` - Target environment type
+  - `target`: `BuildEnvironment` - Target environment type
     - `'client'`: Generates browser environment import map
     - `'server'`: Generates server environment import map
 
@@ -678,7 +678,7 @@ async server(esmx) {
 Gets module's static import path list.
 
 - **Parameters**:
-  - `target`: `BuildSsrTarget` - Build target
+  - `target`: `BuildEnvironment` - Build target
     - `'client'`: Client environment
     - `'server'`: Server environment
   - `specifier`: `string` - Module specifier

--- a/examples/docs/src/en/api/core/module-config.md
+++ b/examples/docs/src/en/api/core/module-config.md
@@ -53,7 +53,7 @@ Union type for export configuration, supporting mixed array (strings and objects
 ```typescript
 type ModuleConfigExportObject = {
     input?: string;
-    inputTarget?: Record<BuildSsrTarget, string | false>;
+    entryPoints?: Record<BuildEnvironment, string | false>;
     rewrite?: boolean;
 };
 ```
@@ -63,9 +63,9 @@ type ModuleConfigExportObject = {
 * **Type**: `string`
 * **Description**: Input file path, relative to project root directory.
 
-#### inputTarget
+#### entryPoints
 
-* **Type**: `Record<BuildSsrTarget, string | false>`
+* **Type**: `Record<BuildEnvironment, string | false>`
 * **Description**: Environment-specific input file configuration. Supports client and server differentiated builds.
 
 #### rewrite
@@ -74,10 +74,10 @@ type ModuleConfigExportObject = {
 * **Default**: `true`
 * **Description**: Whether to rewrite import paths within modules.
 
-### BuildSsrTarget
+### BuildEnvironment
 
 ```typescript
-type BuildSsrTarget = 'client' | 'server';
+type BuildEnvironment = 'client' | 'server';
 ```
 
 Build target environment type.
@@ -101,7 +101,7 @@ interface ParsedModuleConfig {
 ```typescript
 interface ParsedModuleConfigExport {
     name: string;
-    inputTarget: Record<BuildSsrTarget, string | false>;
+    entryPoints: Record<BuildEnvironment, string | false>;
     rewrite: boolean;
 }
 ```
@@ -129,13 +129,13 @@ The framework automatically adds the following default export items for each mod
 ```typescript
 {
   'src/entry.client': {
-    inputTarget: {
+    entryPoints: {
       client: './src/entry.client',
       server: false
     }
   },
   'src/entry.server': {
-    inputTarget: {
+    entryPoints: {
       client: false,
       server: './src/entry.server'
     }
@@ -183,7 +183,7 @@ exports: {
   'axios': 'axios',
   'utils': './src/utils/index.ts',
   'storage': {
-    inputTarget: {
+    entryPoints: {
       client: './src/storage/indexedDB.ts',
       server: './src/storage/filesystem.ts'
     }

--- a/examples/docs/src/en/guide/essentials/module-linking.md
+++ b/examples/docs/src/en/guide/essentials/module-linking.md
@@ -181,7 +181,7 @@ import { formatDate } from 'shared-lib/src/utils/date-utils';  // Correct - dire
 
 #### Advanced exports Configuration
 
-`exports` supports multiple configuration forms. When complex configurations (such as `inputTarget`) are needed, prefix syntactic sugar cannot satisfy requirements, and complete object form is needed:
+`exports` supports multiple configuration forms. When complex configurations (such as `entryPoints`) are needed, prefix syntactic sugar cannot satisfy requirements, and complete object form is needed:
 
 **Array Form**:
 ```typescript
@@ -219,7 +219,7 @@ export default {
       'src/utils/format': {
         input: './src/utils/format',  // Input file path
         rewrite: true,                // Whether to rewrite import paths (default true)
-        inputTarget: {                // Client/server differentiated builds
+        entryPoints: {                // Client/server differentiated builds
           client: './src/utils/format.client',  // Client-specific version
           server: './src/utils/format.server'   // Server-specific version
         }
@@ -229,12 +229,12 @@ export default {
 } satisfies EsmxOptions;
 ```
 
-#### inputTarget Environment Differentiated Builds
+#### entryPoints Environment Differentiated Builds
 
 ```typescript
 exports: {
   'src/storage/db': {
-    inputTarget: {
+    entryPoints: {
       client: './src/storage/indexedDB',  // Client uses IndexedDB
       server: './src/storage/mongoAdapter' // Server uses MongoDB adapter
     }
@@ -247,7 +247,7 @@ Setting `false` can disable builds for specific environments:
 ```typescript
 exports: {
   'src/client-only': {
-    inputTarget: {
+    entryPoints: {
       client: './src/client-feature',  // Only available on client
       server: false                    // Not available on server
     }

--- a/examples/docs/src/zh/api/core/esmx.md
+++ b/examples/docs/src/zh/api/core/esmx.md
@@ -15,11 +15,11 @@ Esmx 是一个基于 Rspack 的高性能 Web 应用框架，提供了完整的�
 
 ## 类型定义
 
-### BuildSsrTarget
+### BuildEnvironment
 
 - **类型定义**:
 ```ts
-type BuildSsrTarget = 'client' | 'server'
+type BuildEnvironment = 'client' | 'server'
 ```
 
 应用程序运行时环境类型：
@@ -518,7 +518,7 @@ async server(esmx) {
 获取构建清单列表。
 
 - **参数**:
-  - `target`: `BuildSsrTarget` - 目标环境类型
+  - `target`: `BuildEnvironment` - 目标环境类型
     - `'client'`: 客户端环境
     - `'server'`: 服务端环境
 
@@ -558,7 +558,7 @@ async server(esmx) {
 获取导入映射对象。
 
 - **参数**:
-  - `target`: `BuildSsrTarget` - 目标环境类型
+  - `target`: `BuildEnvironment` - 目标环境类型
     - `'client'`: 生成浏览器环境的导入映射
     - `'server'`: 生成服务端环境的导入映射
 
@@ -679,7 +679,7 @@ async server(esmx) {
 获取模块的静态导入路径列表。
 
 - **参数**:
-  - `target`: `BuildSsrTarget` - 构建目标
+  - `target`: `BuildEnvironment` - 构建目标
     - `'client'`: 客户端环境
     - `'server'`: 服务端环境
   - `specifier`: `string` - 模块标识符

--- a/examples/docs/src/zh/api/core/module-config.md
+++ b/examples/docs/src/zh/api/core/module-config.md
@@ -53,7 +53,7 @@ type ModuleConfigExportExports =
 ```typescript
 type ModuleConfigExportObject = {
     input?: string;
-    inputTarget?: Record<BuildSsrTarget, string | false>;
+    entryPoints?: Record<BuildEnvironment, string | false>;
     rewrite?: boolean;
 };
 ```
@@ -63,9 +63,9 @@ type ModuleConfigExportObject = {
 * **类型**: `string`
 * **描述**: 输入文件路径，相对于项目根目录。
 
-#### inputTarget
+#### entryPoints
 
-* **类型**: `Record<BuildSsrTarget, string | false>`
+* **类型**: `Record<BuildEnvironment, string | false>`
 * **描述**: 环境特定的输入文件配置。支持客户端和服务端差异化构建。
 
 #### rewrite
@@ -74,10 +74,10 @@ type ModuleConfigExportObject = {
 * **默认值**: `true`
 * **描述**: 是否重写模块内的导入路径。
 
-### BuildSsrTarget
+### BuildEnvironment
 
 ```typescript
-type BuildSsrTarget = 'client' | 'server';
+type BuildEnvironment = 'client' | 'server';
 ```
 
 构建目标环境类型。
@@ -101,7 +101,7 @@ interface ParsedModuleConfig {
 ```typescript
 interface ParsedModuleConfigExport {
     name: string;
-    inputTarget: Record<BuildSsrTarget, string | false>;
+    entryPoints: Record<BuildEnvironment, string | false>;
     rewrite: boolean;
 }
 ```
@@ -129,13 +129,13 @@ interface ParsedModuleConfigExport {
 ```typescript
 {
   'src/entry.client': {
-    inputTarget: {
+    entryPoints: {
       client: './src/entry.client',
       server: false
     }
   },
   'src/entry.server': {
-    inputTarget: {
+    entryPoints: {
       client: false,
       server: './src/entry.server'
     }
@@ -183,7 +183,7 @@ exports: {
   'axios': 'axios',
   'utils': './src/utils/index.ts',
   'storage': {
-    inputTarget: {
+    entryPoints: {
       client: './src/storage/indexedDB.ts',
       server: './src/storage/filesystem.ts'
     }

--- a/examples/docs/src/zh/guide/essentials/module-linking.md
+++ b/examples/docs/src/zh/guide/essentials/module-linking.md
@@ -183,7 +183,7 @@ import { formatDate } from 'shared-lib/src/utils/date-utils';  // 正确 - 直�
 
 #### exports 高级配置
 
-`exports` 支持多种配置形式。当需要复杂配置（如 `inputTarget`）时，前缀语法糖无法满足，需要使用完整的对象形式：
+`exports` 支持多种配置形式。当需要复杂配置（如 `entryPoints`）时，前缀语法糖无法满足，需要使用完整的对象形式：
 
 **数组形式**：
 ```typescript
@@ -221,7 +221,7 @@ export default {
       'src/utils/format': {
         input: './src/utils/format',  // 输入文件路径
         rewrite: true,                // 是否重写导入路径（默认为 true）
-        inputTarget: {                // 客户端/服务端差异化构建
+        entryPoints: {                // 客户端/服务端差异化构建
           client: './src/utils/format.client',  // 客户端特定版本
           server: './src/utils/format.server'   // 服务端特定版本
         }
@@ -231,12 +231,12 @@ export default {
 } satisfies EsmxOptions;
 ```
 
-#### inputTarget 环境差异化构建
+#### entryPoints 环境差异化构建
 
 ```typescript
 exports: {
   'src/storage/db': {
-    inputTarget: {
+    entryPoints: {
       client: './src/storage/indexedDB',  // 客户端使用 IndexedDB
       server: './src/storage/mongoAdapter' // 服务端使用 MongoDB适配器
     }
@@ -249,7 +249,7 @@ exports: {
 ```typescript
 exports: {
   'src/client-only': {
-    inputTarget: {
+    entryPoints: {
       client: './src/client-feature',  // 仅客户端可用
       server: false                    // 服务端不可用
     }

--- a/examples/router-demo/ssr-npm-vue2/src/entry.node.ts
+++ b/examples/router-demo/ssr-npm-vue2/src/entry.node.ts
@@ -15,7 +15,7 @@ export default {
             {
                 'src/render-to-str': {
                     input: './src/render-to-str.ts',
-                    inputTarget: {
+                    entryPoints: {
                         client: false,
                         server: './src/render-to-str.ts'
                     }

--- a/examples/router-demo/ssr-npm-vue3/src/entry.node.ts
+++ b/examples/router-demo/ssr-npm-vue3/src/entry.node.ts
@@ -15,7 +15,7 @@ export default {
             {
                 'src/render-to-str': {
                     input: './src/render-to-str.ts',
-                    inputTarget: {
+                    entryPoints: {
                         client: false,
                         server: './src/render-to-str.ts'
                     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -99,7 +99,7 @@ export interface EsmxOptions {
  * - client: 客户端构建目标，用于生成浏览器端运行的代码
  * - server: 服务端构建目标，用于生成 Node.js 环境运行的代码
  */
-export type BuildSsrTarget = 'client' | 'server';
+export type BuildEnvironment = 'client' | 'server';
 
 /**
  * Esmx 框架的命令枚举。
@@ -765,7 +765,7 @@ export class Esmx {
      *    - 包含模块导出信息
      *    - 记录资源依赖关系
      *
-     * @param target - 目标环境类型
+     * @param env - 目标环境类型
      *   - 'client': 客户端环境
      *   - 'server': 服务端环境
      * @returns 返回只读的构建清单列表
@@ -788,10 +788,10 @@ export class Esmx {
      * ```
      */
     public async getManifestList(
-        target: BuildSsrTarget
+        env: BuildEnvironment
     ): Promise<readonly ManifestJson[]> {
-        return this.readied.cache(`getManifestList-${target}`, async () =>
-            Object.freeze(await getManifestList(target, this.moduleConfig))
+        return this.readied.cache(`getManifestList-${env}`, async () =>
+            Object.freeze(await getManifestList(env, this.moduleConfig))
         );
     }
 
@@ -813,7 +813,7 @@ export class Esmx {
      *    - 自动处理模块路径
      *    - 支持动态基础路径
      *
-     * @param target - 目标环境类型
+     * @param env - 目标环境类型
      *   - 'client': 生成浏览器环境的导入映射
      *   - 'server': 生成服务端环境的导入映射
      * @returns 返回只读的导入映射对象
@@ -844,13 +844,13 @@ export class Esmx {
      * ```
      */
     public async getImportMap(
-        target: BuildSsrTarget
+        env: BuildEnvironment
     ): Promise<Readonly<ImportMap>> {
-        return this.readied.cache(`getImportMap-${target}`, async () => {
+        return this.readied.cache(`getImportMap-${env}`, async () => {
             const { moduleConfig } = this.readied;
-            const manifests = await this.getManifestList(target);
+            const manifests = await this.getManifestList(env);
             let json: ImportMap = {};
-            switch (target) {
+            switch (env) {
                 case 'client':
                     json = getImportMap({
                         manifests,
@@ -1042,7 +1042,7 @@ document.head.appendChild(script);
     /**
      * 获取模块的静态导入路径列表。
      *
-     * @param target - 构建目标（'client' | 'server'）
+     * @param env - 构建目标（'client' | 'server'）
      * @param specifier - 模块标识符
      * @returns 返回静态导入路径列表，如果未找到则返回 null
      * @throws {NotReadyError} 在框架实例未初始化时调用此方法会抛出错误
@@ -1057,15 +1057,15 @@ document.head.appendChild(script);
      * ```
      */
     public async getStaticImportPaths(
-        target: BuildSsrTarget,
+        env: BuildEnvironment,
         specifier: string
     ) {
         return this.readied.cache(
-            `getStaticImportPaths-${target}-${specifier}`,
+            `getStaticImportPaths-${env}-${specifier}`,
             async () => {
                 const result = await getStaticImportPaths(
                     specifier,
-                    await this.getImportMap(target),
+                    await this.getImportMap(env),
                     this.moduleConfig
                 );
                 if (!result) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export {
     type EsmxOptions,
     type COMMAND,
-    type BuildSsrTarget,
+    type BuildEnvironment,
     type ImportMap,
     type SpecifierMap,
     type ScopesMap,

--- a/packages/core/src/manifest-json.ts
+++ b/packages/core/src/manifest-json.ts
@@ -1,7 +1,7 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 
-import type { BuildSsrTarget } from './core';
+import type { BuildEnvironment } from './core';
 import type { ParsedModuleConfig } from './module-config';
 
 export interface ManifestJson {
@@ -100,12 +100,12 @@ export interface ManifestJsonChunkSizes {
  * Get service manifest files
  */
 export async function getManifestList(
-    target: BuildSsrTarget,
+    env: BuildEnvironment,
     moduleConfig: ParsedModuleConfig
 ): Promise<ManifestJson[]> {
     return Promise.all(
         Object.values(moduleConfig.links).map(async (item) => {
-            const filename = path.resolve(item[target], 'manifest.json');
+            const filename = path.resolve(item[env], 'manifest.json');
             try {
                 const data: ManifestJson = await JSON.parse(
                     await fsp.readFile(filename, 'utf-8')
@@ -114,7 +114,7 @@ export async function getManifestList(
                 return data;
             } catch (e) {
                 throw new Error(
-                    `'${item.name}' service '${filename}' file read error on target '${target}': ${e instanceof Error ? e.message : String(e)}`
+                    `'${item.name}' service '${filename}' file read error on environment '${env}': ${e instanceof Error ? e.message : String(e)}`
                 );
             }
         })

--- a/packages/core/src/module-config.test.ts
+++ b/packages/core/src/module-config.test.ts
@@ -182,7 +182,7 @@ describe('module-config', () => {
                 expect(result.exports['src/entry.client']).toEqual({
                     name: 'src/entry.client',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/entry.client',
                         server: false
                     }
@@ -191,7 +191,7 @@ describe('module-config', () => {
                 expect(result.exports['src/entry.server']).toEqual({
                     name: 'src/entry.server',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: false,
                         server: './src/entry.server'
                     }
@@ -217,7 +217,7 @@ describe('module-config', () => {
                 expect(result.exports.axios).toEqual({
                     name: 'axios',
                     rewrite: false,
-                    inputTarget: {
+                    entryPoints: {
                         client: 'axios',
                         server: 'axios'
                     }
@@ -226,7 +226,7 @@ describe('module-config', () => {
                 expect(result.exports.lodash).toEqual({
                     name: 'lodash',
                     rewrite: false,
-                    inputTarget: {
+                    entryPoints: {
                         client: 'lodash',
                         server: 'lodash'
                     }
@@ -254,7 +254,7 @@ describe('module-config', () => {
                 expect(result.exports['src/utils/format']).toEqual({
                     name: 'src/utils/format',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/utils/format',
                         server: './src/utils/format'
                     }
@@ -263,7 +263,7 @@ describe('module-config', () => {
                 expect(result.exports['src/components/Button']).toEqual({
                     name: 'src/components/Button',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/components/Button',
                         server: './src/components/Button'
                     }
@@ -272,7 +272,7 @@ describe('module-config', () => {
                 expect(result.exports['src/api/client']).toEqual({
                     name: 'src/api/client',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/api/client',
                         server: './src/api/client'
                     }
@@ -338,7 +338,7 @@ describe('module-config', () => {
                 expect(result.exports['custom-api']).toEqual({
                     name: 'custom-api',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/api/custom.ts',
                         server: './src/api/custom.ts'
                     }
@@ -347,7 +347,7 @@ describe('module-config', () => {
                 expect(result.exports.utils).toEqual({
                     name: 'utils',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/utils/index.ts',
                         server: './src/utils/index.ts'
                     }
@@ -399,7 +399,7 @@ describe('module-config', () => {
                 expect(result.exports.axios).toEqual({
                     name: 'axios',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: 'axios',
                         server: 'axios'
                     }
@@ -408,7 +408,7 @@ describe('module-config', () => {
                 expect(result.exports.utils).toEqual({
                     name: 'utils',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/utils/index.ts',
                         server: './src/utils/index.ts'
                     }
@@ -420,7 +420,7 @@ describe('module-config', () => {
                 const config: ModuleConfig = {
                     exports: {
                         storage: {
-                            inputTarget: {
+                            entryPoints: {
                                 client: './src/storage/indexedDB.ts',
                                 server: './src/storage/filesystem.ts'
                             },
@@ -444,7 +444,7 @@ describe('module-config', () => {
                 expect(result.exports.storage).toEqual({
                     name: 'storage',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/storage/indexedDB.ts',
                         server: './src/storage/filesystem.ts'
                     }
@@ -453,25 +453,25 @@ describe('module-config', () => {
                 expect(result.exports['npm-package']).toEqual({
                     name: 'npm-package',
                     rewrite: false,
-                    inputTarget: {
+                    entryPoints: {
                         client: 'some-package',
                         server: 'some-package'
                     }
                 });
             });
 
-            it('should handle inputTarget with false values', () => {
+            it('should handle entryPoints with false values', () => {
                 // Arrange
                 const config: ModuleConfig = {
                     exports: {
                         'client-only': {
-                            inputTarget: {
+                            entryPoints: {
                                 client: './src/client-feature.ts',
                                 server: false
                             }
                         },
                         'server-only': {
-                            inputTarget: {
+                            entryPoints: {
                                 client: false,
                                 server: './src/server-feature.ts'
                             }
@@ -490,7 +490,7 @@ describe('module-config', () => {
                 expect(result.exports['client-only']).toEqual({
                     name: 'client-only',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/client-feature.ts',
                         server: false
                     }
@@ -499,7 +499,7 @@ describe('module-config', () => {
                 expect(result.exports['server-only']).toEqual({
                     name: 'server-only',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: false,
                         server: './src/server-feature.ts'
                     }
@@ -515,9 +515,9 @@ describe('module-config', () => {
                         // Simple string mapping
                         simple: './src/simple.ts',
 
-                        // Complete object with inputTarget
+                        // Complete object with entryPoints
                         complex: {
-                            inputTarget: {
+                            entryPoints: {
                                 client: './src/complex.client.ts',
                                 server: './src/complex.server.ts'
                             },
@@ -547,7 +547,7 @@ describe('module-config', () => {
                 expect(result.exports.simple).toEqual({
                     name: 'simple',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/simple.ts',
                         server: './src/simple.ts'
                     }
@@ -556,7 +556,7 @@ describe('module-config', () => {
                 expect(result.exports.complex).toEqual({
                     name: 'complex',
                     rewrite: false,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/complex.client.ts',
                         server: './src/complex.server.ts'
                     }
@@ -565,7 +565,7 @@ describe('module-config', () => {
                 expect(result.exports['with-input']).toEqual({
                     name: 'with-input',
                     rewrite: true,
-                    inputTarget: {
+                    entryPoints: {
                         client: './src/with-input.ts',
                         server: './src/with-input.ts'
                     }
@@ -574,7 +574,7 @@ describe('module-config', () => {
                 expect(result.exports['with-rewrite']).toEqual({
                     name: 'with-rewrite',
                     rewrite: false,
-                    inputTarget: {
+                    entryPoints: {
                         client: 'with-rewrite',
                         server: 'with-rewrite'
                     }
@@ -610,7 +610,7 @@ describe('module-config', () => {
                 const config: ModuleConfig = {
                     exports: {
                         'fallback-test': {
-                            // No input or inputTarget specified
+                            // No input or entryPoints specified
                             rewrite: false
                         }
                     }
@@ -624,7 +624,7 @@ describe('module-config', () => {
                 );
 
                 // Assert
-                expect(result.exports['fallback-test'].inputTarget).toEqual({
+                expect(result.exports['fallback-test'].entryPoints).toEqual({
                     client: 'fallback-test',
                     server: 'fallback-test'
                 });
@@ -790,9 +790,9 @@ describe('module-config', () => {
             const exportConfig: ParsedModuleConfigExport = result.exports.axios;
             expect(typeof exportConfig.name).toBe('string');
             expect(typeof exportConfig.rewrite).toBe('boolean');
-            expect(typeof exportConfig.inputTarget).toBe('object');
-            expect(typeof exportConfig.inputTarget.client).toBe('string');
-            expect(typeof exportConfig.inputTarget.server).toBe('string');
+            expect(typeof exportConfig.entryPoints).toBe('object');
+            expect(typeof exportConfig.entryPoints.client).toBe('string');
+            expect(typeof exportConfig.entryPoints.server).toBe('string');
         });
     });
 });

--- a/packages/core/src/module-config.ts
+++ b/packages/core/src/module-config.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { BuildSsrTarget } from './core';
+import type { BuildEnvironment } from './core';
 
 /**
  * Core configuration interface for the module system.
@@ -82,13 +82,13 @@ export type ModuleConfigExportObject = {
      *
      * @example
      * ```typescript
-     * inputTarget: {
+     * entryPoints: {
      *   client: './src/storage/indexedDB.ts',
      *   server: './src/storage/filesystem.ts'
      * }
      * ```
      */
-    inputTarget?: Record<BuildSsrTarget, string | false>;
+    entryPoints?: Record<BuildEnvironment, string | false>;
 
     /**
      * Whether to rewrite import paths within modules.
@@ -157,7 +157,7 @@ export interface ParsedModuleConfigExport {
     name: string;
 
     /** Resolved input targets for different build environments */
-    inputTarget: Record<BuildSsrTarget, string | false>;
+    entryPoints: Record<BuildEnvironment, string | false>;
 
     /** Whether to rewrite import paths within this module */
     rewrite: boolean;
@@ -258,13 +258,13 @@ function getExports(config: ModuleConfig = {}) {
 
     const exports: Record<string, ModuleConfigExportObject | string> = {
         'src/entry.client': {
-            inputTarget: {
+            entryPoints: {
                 client: './src/entry.client',
                 server: false
             }
         },
         'src/entry.server': {
-            inputTarget: {
+            entryPoints: {
                 client: false,
                 server: './src/entry.server'
             }
@@ -312,12 +312,12 @@ function getExports(config: ModuleConfig = {}) {
                       input: value
                   }
                 : value;
-        const client = opts.inputTarget?.client ?? opts.input ?? name;
-        const server = opts.inputTarget?.server ?? opts.input ?? name;
+        const client = opts.entryPoints?.client ?? opts.input ?? name;
+        const server = opts.entryPoints?.server ?? opts.input ?? name;
         result[name] = {
             name,
             rewrite: opts.rewrite ?? true,
-            inputTarget: {
+            entryPoints: {
                 client,
                 server
             }

--- a/packages/rspack/src/rspack/chain-config.ts
+++ b/packages/rspack/src/rspack/chain-config.ts
@@ -155,10 +155,10 @@ function createModuleLinkConfig(esmx: Esmx, buildTarget: BuildTarget) {
 
     const exports: Record<string, { rewrite: boolean; file: string }> = {};
     for (const [name, item] of Object.entries(esmx.moduleConfig.exports)) {
-        if (item.inputTarget[buildTarget]) {
+        if (item.entryPoints[buildTarget]) {
             exports[name] = {
                 rewrite: item.rewrite,
-                file: item.inputTarget[buildTarget]
+                file: item.entryPoints[buildTarget]
             };
         }
     }

--- a/packages/rspack/src/rspack/config.ts
+++ b/packages/rspack/src/rspack/config.ts
@@ -144,10 +144,10 @@ function createModuleLinkPlugin(esmx: Esmx, buildTarget: BuildTarget): Plugin {
         }
     > = {};
     for (const [name, item] of Object.entries(esmx.moduleConfig.exports)) {
-        if (item.inputTarget[buildTarget]) {
+        if (item.entryPoints[buildTarget]) {
             exports[name] = {
                 rewrite: item.rewrite,
-                file: item.inputTarget[buildTarget]
+                file: item.entryPoints[buildTarget]
             };
         }
     }


### PR DESCRIPTION
## Summary

This PR refactors all code, types, tests, and documentation to unify the naming of inputTarget → entryPoints and BuildSsrTarget → BuildEnvironment. This affects all module export configs, type definitions, and related documentation. No logic is changed, only naming and documentation are unified for consistency.

## Related links

None

## Checklist

- [x] Tests updated (or not required)
- [x] Documentation updated (or not required)
