### PR TITLE
fix(template): move router package to devdependencies

### DIFF
--- a/packages/create-esmx/template/shared-modules/package.json
+++ b/packages/create-esmx/template/shared-modules/package.json
@@ -13,10 +13,10 @@
         "build:type": "tsc --declaration --emitDeclarationOnly --outDir dist/src && tsc-alias -p tsconfig.json --outDir dist/src"
     },
     "dependencies": {
-        "@esmx/core": "{{esmxVersion}}",
-        "@esmx/router": "{{esmxVersion}}"
+        "@esmx/core": "{{esmxVersion}}"
     },
     "devDependencies": {
+        "@esmx/router": "{{esmxVersion}}",
         "tsc-alias": "^1.8.16",
         "@esmx/rspack": "{{esmxVersion}}",
         "@types/node": "^24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,10 +520,10 @@ importers:
       '@esmx/core':
         specifier: workspace:*
         version: link:../../../packages/core
+    devDependencies:
       '@esmx/router':
         specifier: workspace:*
         version: link:../../../packages/router
-    devDependencies:
       '@esmx/rspack':
         specifier: workspace:*
         version: link:../../../packages/rspack


### PR DESCRIPTION
## Summary

This change moves the `@esmx/router` package from dependencies to devDependencies in the shared modules template. This is a configuration fix to ensure proper dependency management in the template structure.

## Related links

N/A

## Checklist

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)