### PR TITLE
feat(router): enhance rootStyle handling with null support and improved option precedence

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -244,8 +244,6 @@ export class Router {
         });
 
         const router = new Router({
-            ...this.options,
-            mode: RouterMode.memory,
             rootStyle: {
                 position: 'fixed',
                 top: '0',
@@ -258,6 +256,8 @@ export class Router {
                 alignItems: 'center',
                 justifyContent: 'center'
             },
+            ...this.options,
+            mode: RouterMode.memory,
             root: undefined,
             ...layerOptions.routerOptions,
             handleBackBoundary(router) {

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -267,7 +267,7 @@ export interface RouterOptions {
     normalizeURL?: (to: URL, from: URL | null) => URL;
     fallback?: RouteHandleHook;
 
-    rootStyle?: Partial<CSSStyleDeclaration> | false;
+    rootStyle?: Partial<CSSStyleDeclaration> | false | null;
     layer?: boolean;
     zIndex?: number;
     handleBackBoundary?: (router: Router) => void;

--- a/packages/router/tests/micro-app.dom.test.ts
+++ b/packages/router/tests/micro-app.dom.test.ts
@@ -471,6 +471,23 @@ describe('MicroApp', () => {
             expect(microApp.root!.style.fontSize).toBe('16px');
         });
 
+        it('should not apply any style when rootStyle is null', () => {
+            const mockApp = createMockApp();
+            const mockFactory = vi.fn().mockReturnValue(mockApp);
+
+            const router = createMockRouter({
+                matched: [{ app: 'test-app' }],
+                options: { apps: { 'test-app': mockFactory } },
+                parsedOptions: {
+                    rootStyle: null
+                }
+            });
+
+            microApp._update(router);
+
+            expect(microApp.root!.style.cssText).toBe('');
+        });
+
         it('should unmount the old application if it exists', () => {
             const oldApp = createMockApp();
             const newApp = createMockApp();
@@ -653,6 +670,21 @@ describe('MicroApp', () => {
                 matched: [{ app: 'test-app' }],
                 options: { apps: { 'test-app': mockFactory } },
                 parsedOptions: { rootStyle: false }
+            });
+
+            microApp._update(router);
+
+            expect(microApp.root!.style.cssText).toBe('');
+        });
+
+        it('should correctly handle rootStyle being null', () => {
+            const mockApp = createMockApp();
+            const mockFactory = vi.fn().mockReturnValue(mockApp);
+
+            const router = createMockRouter({
+                matched: [{ app: 'test-app' }],
+                options: { apps: { 'test-app': mockFactory } },
+                parsedOptions: { rootStyle: null }
             });
 
             microApp._update(router);

--- a/packages/router/tests/navigation.test.ts
+++ b/packages/router/tests/navigation.test.ts
@@ -424,7 +424,7 @@ describe.concurrent('subscribeMemory', () => {
 });
 
 describe('Navigation', () => {
-    const createTestOptions = (opts: Partial<RouterOptions> = {}) => {
+    const createTestOptions = () => {
         const baseOptions: RouterOptions = {
             context: {},
             routes: [],
@@ -437,18 +437,10 @@ describe('Navigation', () => {
             fallback: () => {},
             rootStyle: false,
             handleBackBoundary: () => {},
-            handleLayerClose: () => {},
-            ...opts
+            handleLayerClose: () => {}
         };
         return parsedOptions(baseOptions);
     };
-
-    test('should handle rootStyle being null in options', () => {
-        const opts = createTestOptions({
-            rootStyle: null
-        });
-        expect(opts.rootStyle).toBeNull();
-    });
 
     test('should provide access to history length', () => {
         const nav = new Navigation({ mode: RouterMode.memory } as any);

--- a/packages/router/tests/navigation.test.ts
+++ b/packages/router/tests/navigation.test.ts
@@ -424,7 +424,7 @@ describe.concurrent('subscribeMemory', () => {
 });
 
 describe('Navigation', () => {
-    const createTestOptions = () => {
+    const createTestOptions = (opts: Partial<RouterOptions> = {}) => {
         const baseOptions: RouterOptions = {
             context: {},
             routes: [],
@@ -437,10 +437,18 @@ describe('Navigation', () => {
             fallback: () => {},
             rootStyle: false,
             handleBackBoundary: () => {},
-            handleLayerClose: () => {}
+            handleLayerClose: () => {},
+            ...opts
         };
         return parsedOptions(baseOptions);
     };
+
+    test('should handle rootStyle being null in options', () => {
+        const opts = createTestOptions({
+            rootStyle: null
+        });
+        expect(opts.rootStyle).toBeNull();
+    });
 
     test('should provide access to history length', () => {
         const nav = new Navigation({ mode: RouterMode.memory } as any);


### PR DESCRIPTION
## Summary

This PR enhances the router's `rootStyle` handling to improve flexibility and developer experience when creating layered routes. The changes include:

### Key Changes:
1. **Adjusted rootStyle priority in router options**: Modified the order of option merging in the Router constructor to allow preset `rootStyle` values to be properly applied when creating routes. The default rootStyle is now applied first, then overridden by user-provided options.

2. **Enhanced type definitions**: Updated the `rootStyle` type to accept `null` in addition to existing types (`Partial<CSSStyleDeclaration>` or `false`), providing more granular control over styling behavior.

3. **Comprehensive test coverage**: Added robust test cases to ensure proper handling of `null` rootStyle values in both micro-app scenarios and navigation contexts.

### Technical Details:
- Fixed option precedence in `packages/router/src/router.ts` by moving `...this.options` after the default rootStyle configuration
- Updated `RouterOptions` interface in `packages/router/src/types.ts` to include `null` as a valid rootStyle value
- Added 3 new test cases covering null rootStyle scenarios in micro-app DOM tests and navigation tests

This enhancement provides developers with better control over router styling while maintaining backward compatibility.

## Related links

<!-- Related issues or discussions. -->


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required)
- [ ] Documentation updated (or not required)
