### PR TITLE
feat(router): add context getter to Router instance

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -40,6 +40,10 @@ export class Router {
         return route;
     }
 
+    public get context() {
+        return this.options.context;
+    }
+
     public get root() {
         return this.parsedOptions.root;
     }


### PR DESCRIPTION
## Summary

Add a context getter to the Router instance to provide direct access to the router's context configuration. This enhancement allows developers to easily retrieve the context from a Router instance without accessing the internal options object directly.

## Related links

<!-- Related issues or discussions. -->


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required)
- [x] Documentation updated (or not required)