### PR TITLE
ci: update Windows runner to windows-2022 for stability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         node: [24]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

Update GitHub Actions Windows runner from `windows-latest` to `windows-2022` to avoid migration issues when GitHub migrates `windows-latest` to Windows Server 2025 in September 2025.

The `windows-2022` runner will be supported until 2028, ensuring long-term build stability and avoiding potential tooling differences that may occur with the new Windows Server 2025 image.

## Related links

- GitHub Actions runner migration announcement: Windows Server 2025 migration begins September 2, 2025
- Windows 2022 runner support: Maintained for the next 3 years until 2028

## Checklist

- [x] Tests updated (or not required)
- [x] Documentation updated (or not required)