### PR TITLE
feat(rspack): enable native watcher for improved build performance

### DIFF
--- a/packages/rspack/src/rspack/chain-config.ts
+++ b/packages/rspack/src/rspack/chain-config.ts
@@ -112,6 +112,9 @@ export function createChainConfig(
             })
         ]);
     }
+    config.experiments({
+        nativeWatcher: true
+    });
 
     return config;
 }


### PR DESCRIPTION
## Summary

Enable native watcher in Rspack configuration to improve file watching performance during development. This change adds `nativeWatcher: true` to the Rspack experiments configuration, which leverages the native file system watcher for better performance and reliability.

## Related links

- Closes #186 (from recent commits)

## Checklist

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)