### PR TITLE
feat: remove sizes from manifest json

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,6 @@ export {
 export type {
     ManifestJson,
     ManifestJsonChunk,
-    ManifestJsonChunkSizes,
     ManifestJsonChunks,
     ManifestJsonExport,
     ManifestJsonExports

--- a/packages/core/src/manifest-json.ts
+++ b/packages/core/src/manifest-json.ts
@@ -75,25 +75,6 @@ export interface ManifestJsonChunk {
      * Other resource files.
      */
     resources: string[];
-    /**
-     * Build output sizes.
-     */
-    sizes: ManifestJsonChunkSizes;
-}
-
-export interface ManifestJsonChunkSizes {
-    /**
-     * JavaScript file size in bytes
-     */
-    js: number;
-    /**
-     * CSS file size in bytes
-     */
-    css: number;
-    /**
-     * Resource file size in bytes
-     */
-    resource: number;
 }
 
 /**

--- a/packages/rspack-module-link-plugin/src/manifest.ts
+++ b/packages/rspack-module-link-plugin/src/manifest.ts
@@ -144,17 +144,11 @@ function getChunks(
 
         const css = chunk.files?.filter((file) => file.endsWith('.css')) ?? [];
         const resources = chunk.auxiliaryFiles ?? [];
-        const sizes = chunk.sizes ?? {};
         buildChunks[name] = {
             name,
             js,
             css,
-            resources,
-            sizes: {
-                js: (sizes?.javascript ?? 0) + (sizes.runtime ?? 0),
-                css: (sizes.css ?? 0) + (sizes['css/mini-extract'] ?? 0),
-                resource: sizes.asset ?? 0
-            }
+            resources
         };
     }
     return buildChunks;

--- a/packages/rspack-module-link-plugin/src/types.ts
+++ b/packages/rspack-module-link-plugin/src/types.ts
@@ -3,7 +3,6 @@ export type {
     ManifestJson,
     ManifestJsonChunks,
     ManifestJsonChunk,
-    ManifestJsonChunkSizes,
     ManifestJsonExport,
     ManifestJsonExports
 } from '@esmx/core';


### PR DESCRIPTION
## Summary

Remove sizes related properties and types from manifest JSON structure to simplify the interface and eliminate unnecessary size tracking.

- Remove `sizes` property from `ManifestJsonChunk` interface
- Remove `ManifestJsonChunkSizes` interface definition
- Update all related exports in core and plugin packages
- Clean up size calculation logic in rspack-module-link-plugin

## Related links

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required)
- [x] Documentation updated (or not required)