### PR TITLE
feat: simplify rspack module link plugin configuration

### DIFF
--- a/packages/rspack-module-link-plugin/src/config.ts
+++ b/packages/rspack-module-link-plugin/src/config.ts
@@ -1,11 +1,18 @@
 import type { RspackOptionsNormalized } from '@rspack/core';
-import type { ParsedModuleLinkPluginOptions } from './types';
 
-export function initConfig(
-    options: RspackOptionsNormalized,
-    opts: ParsedModuleLinkPluginOptions
-) {
+export function initConfig(options: RspackOptionsNormalized) {
     const isProduction = options.mode === 'production';
+
+    options.output = {
+        ...options.output,
+        module: true,
+        chunkFormat: 'module',
+        chunkLoading: 'import',
+        workerChunkLoading: 'import',
+        library: {
+            type: 'module'
+        }
+    };
     options.experiments = {
         ...options.experiments,
         outputModule: true,
@@ -13,6 +20,7 @@ export function initConfig(
             bundlerInfo: { force: false }
         }
     };
+
     options.module = {
         ...options.module,
         parser: {
@@ -24,26 +32,13 @@ export function initConfig(
             }
         }
     };
-    options.output = {
-        ...options.output,
-        iife: false,
-        uniqueName: opts.name,
-        chunkFormat: 'module',
-        module: true,
-        library: {
-            type: isProduction ? 'modern-module' : 'module'
-        },
-        environment: {
-            ...options.output.environment,
-            dynamicImport: true,
-            dynamicImportInWorker: true,
-            module: true
-        }
-    };
     options.optimization = {
         ...options.optimization,
-        avoidEntryIife: isProduction,
-        concatenateModules: isProduction,
-        usedExports: isProduction
+        // See detail: https://github.com/web-infra-dev/rspack/issues/11578
+        // runtimeChunk: 'single',
+        // splitChunks: {
+        //     chunks: 'all'
+        // },
+        avoidEntryIife: isProduction
     };
 }

--- a/packages/rspack-module-link-plugin/src/index.ts
+++ b/packages/rspack-module-link-plugin/src/index.ts
@@ -11,7 +11,7 @@ export function moduleLinkPlugin(
 ): RspackPluginFunction {
     const opts = parseOptions(options);
     return (compiler: Compiler) => {
-        initConfig(compiler.options, opts);
+        initConfig(compiler.options);
         initEntry(compiler.options, opts);
         initExternal(compiler, opts);
         intiManifestJson(compiler, opts);


### PR DESCRIPTION
## Summary

This PR simplifies the Rspack module link plugin configuration by:

- Removing the dependency on  from the  function
- Simplifying the output configuration with unified module settings
- Removing production-specific library type differentiation
- Commenting out runtimeChunk and splitChunks optimizations due to Rspack issues (see: https://github.com/web-infra-dev/rspack/issues/11578)

The changes make the configuration more streamlined and easier to maintain while maintaining the same functionality.

## Related links

- https://github.com/web-infra-dev/rspack/issues/11578

## Checklist

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)