### PR TITLE
feat: add scroll position management to router navigation

### DIFF
--- a/examples/router-demo-vue2/src/create-app.ts
+++ b/examples/router-demo-vue2/src/create-app.ts
@@ -5,7 +5,7 @@
 
 import { Router, RouterInstance } from '@esmx/router';
 import { RouterPlugin, RouterView, useProvideRouter } from '@esmx/router-vue';
-import Vue from 'vue';
+import Vue, { nextTick } from 'vue';
 import { routes } from './routes';
 
 const isBrowser = typeof window === 'object' && typeof document === 'object';
@@ -27,6 +27,7 @@ export async function createApp({
         root: '#root',
         base: new URL(base),
         routes,
+        nextTick: nextTick,
         apps(router) {
             const app = new Vue({
                 setup() {

--- a/examples/router-demo-vue2/src/views/home.vue
+++ b/examples/router-demo-vue2/src/views/home.vue
@@ -19,7 +19,8 @@
                     </button>
                     <RouterLink :to="{
                         path: `/news/${id}`,
-                        state: { id }
+                        state: { id },
+                        keepScrollPosition: true
                     }" class="card-link">
                         查看详情
                         <span class="link-icon">→</span>

--- a/packages/router/src/options.ts
+++ b/packages/router/src/options.ts
@@ -83,6 +83,7 @@ export function parsedOptions(
         matcher: createMatcher(routes, compiledRoutes),
         normalizeURL: options.normalizeURL ?? ((url) => url),
         fallback: options.fallback ?? fallback,
+        nextTick: options.nextTick ?? (() => {}),
         handleBackBoundary: options.handleBackBoundary ?? (() => {}),
         handleLayerClose: options.handleLayerClose ?? (() => {})
     });

--- a/packages/router/src/route-task.ts
+++ b/packages/router/src/route-task.ts
@@ -23,10 +23,7 @@ export class RouteTaskController {
     }
 
     shouldCancel(name: string): boolean {
-        if (this._aborted) {
-            return true;
-        }
-        return false;
+        return this._aborted;
     }
 }
 

--- a/packages/router/src/scroll.ts
+++ b/packages/router/src/scroll.ts
@@ -1,0 +1,108 @@
+import { isBrowser } from './util';
+
+/** Internal {@link ScrollToOptions | `ScrollToOptions`}: `left` and `top` properties always have values */
+interface _ScrollPosition extends ScrollToOptions {
+    left: number;
+    top: number;
+}
+
+export interface ScrollPositionElement extends ScrollToOptions {
+    /**
+     * A valid CSS selector. Some special characters need to be escaped (https://mathiasbynens.be/notes/css-escapes).
+     * @example
+     * Here are some examples:
+     *
+     * - `.title`
+     * - `.content:first-child`
+     * - `#marker`
+     * - `#marker\~with\~symbols`
+     * - `#marker.with.dot`: Selects `class="with dot" id="marker"`, not `id="marker.with.dot"`
+     *
+     */
+    el: string | Element;
+}
+
+/** Scroll parameters */
+export type ScrollPosition = ScrollToOptions | ScrollPositionElement;
+
+/** Get current window scroll position */
+export const winScrollPos = (): _ScrollPosition => ({
+    left: window.scrollX,
+    top: window.scrollY
+});
+
+/** Get element position for scrolling in document */
+function getElementPosition(
+    el: Element,
+    offset: ScrollToOptions
+): _ScrollPosition {
+    const docRect = document.documentElement.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+
+    return {
+        behavior: offset.behavior,
+        left: elRect.left - docRect.left - (offset.left || 0),
+        top: elRect.top - docRect.top - (offset.top || 0)
+    };
+}
+
+/** Scroll to specified position */
+export function scrollToPosition(position: ScrollPosition): void {
+    if ('el' in position) {
+        const positionEl = position.el;
+
+        const el =
+            typeof positionEl === 'string'
+                ? document.querySelector(positionEl)
+                : positionEl;
+
+        if (!el) return;
+
+        position = getElementPosition(el, position);
+    }
+
+    if ('scrollBehavior' in document.documentElement.style) {
+        window.scrollTo(position);
+    } else {
+        window.scrollTo(
+            Number.isFinite(position.left) ? position.left! : window.scrollX,
+            Number.isFinite(position.top) ? position.top! : window.scrollY
+        );
+    }
+}
+
+/** Stored scroll positions */
+export const scrollPositions = new Map<string, _ScrollPosition>();
+
+const POSITION_KEY = '__scroll_position_key';
+
+/** Save scroll position */
+export function saveScrollPosition(
+    key: string,
+    scrollPosition = winScrollPos()
+) {
+    scrollPosition = { ...scrollPosition };
+    scrollPositions.set(key, scrollPosition);
+
+    try {
+        if (location.href !== key) return;
+        // preserve the existing history state as it could be overridden by the user
+        const stateCopy = {
+            ...(history.state || {}),
+            [POSITION_KEY]: scrollPosition
+        };
+        history.replaceState(stateCopy, '');
+    } catch (error) {}
+}
+
+/** Get saved scroll position */
+export function getSavedScrollPosition(
+    key: string,
+    defaultValue: _ScrollPosition | null = null
+): _ScrollPosition | null {
+    const scroll = scrollPositions.get(key) || history.state[POSITION_KEY];
+
+    // Saved scroll position should not be used multiple times, next time should use newly saved position
+    scrollPositions.delete(key);
+    return scroll || defaultValue;
+}

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -91,6 +91,7 @@ export interface RouteLocation {
     queryArray?: Record<string, string[] | undefined>;
     hash?: string;
     state?: RouteState;
+    /** When `true`, maintains current scroll position after navigation (default behavior scrolls to top) */
     keepScrollPosition?: boolean;
     statusCode?: number | null;
     layer?: RouteLayerOptions | null;
@@ -266,6 +267,7 @@ export interface RouterOptions {
     apps?: RouterMicroApp;
     normalizeURL?: (to: URL, from: URL | null) => URL;
     fallback?: RouteHandleHook;
+    nextTick?: () => Awaitable<void>;
 
     rootStyle?: Partial<CSSStyleDeclaration> | false | null;
     layer?: boolean;


### PR DESCRIPTION
## Summary

Add scroll position management to router navigation

- Implement `keepScrollPosition` option in `RouteLocation` to maintain scroll position after navigation.
- Introduce scroll position utilities for saving and retrieving scroll positions.
- Update createApp and route transition logic to handle scroll restoration.

## Related links

<!-- Related issues or discussions. -->


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)
