### PR TITLE
feat(router): add requireIndex option for route matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ packages/**/coverage
 remotes
 /Dockerfile
 examples/templates/
+.codebuddy

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -28,6 +28,8 @@ export function createMatcher(
                     matches.unshift(item);
                     return true;
                 }
+                // At this point, children exist but none matched — if requireIndex is true, skip self-match
+                if (item.requireIndex && item.children.length) continue;
                 const result = item.match(matchPath);
                 if (result) {
                     matches.unshift(item);
@@ -56,6 +58,7 @@ export function createRouteMatches(
             match: match(compilePath),
             compile: compile(compilePath),
             meta: route.meta || {},
+            requireIndex: route.requireIndex ?? false,
             children: Array.isArray(route.children)
                 ? createRouteMatches(route.children, compilePath)
                 : []

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -115,6 +115,43 @@ export interface RouteConfig {
     layer?: boolean;
 
     /**
+     * Require an index child route to match the parent path
+     *
+     * When set to `true`, the parent route will not match its own path
+     * if no child route matches. The parent route requires a `path: ''`
+     * index child route to match the parent path itself.
+     *
+     * - `requireIndex: false` (default): If no child route matches,
+     *   the matcher falls back to matching the parent route itself
+     * - `requireIndex: true`: If no child route matches, the parent
+     *   route is skipped entirely (no fallback to self-match)
+     *
+     * @default false
+     *
+     * @example
+     * ```typescript
+     * // requireIndex: true - /A won't match without index child
+     * {
+     *   path: '/A',
+     *   requireIndex: true,
+     *   children: [
+     *     { path: '', component: IndexComponent },  // /A matches this
+     *     { path: 'a', component: AComponent }       // /A/a matches this
+     *   ]
+     * }
+     *
+     * // Default behavior - /A matches even without index child
+     * {
+     *   path: '/A',
+     *   children: [
+     *     { path: 'a', component: AComponent }  // /A/a matches, /A also matches (parent self)
+     *   ]
+     * }
+     * ```
+     */
+    requireIndex?: boolean;
+
+    /**
      * Route override function for hybrid app development
      *
      * Note: Override is not executed during initial route loading
@@ -136,6 +173,8 @@ export interface RouteConfig {
 }
 
 export interface RouteParsedConfig extends RouteConfig {
+    /** Require an index child route to match the parent path (always has a value after parsing) */
+    requireIndex: boolean;
     compilePath: string;
     children: RouteParsedConfig[];
     match: MatchFunction;

--- a/packages/router/tests/matcher.test.ts
+++ b/packages/router/tests/matcher.test.ts
@@ -1,5 +1,9 @@
 import { assert, describe, test } from 'vitest';
-import { createMatcher, joinPathname } from '../src/matcher';
+import {
+    createMatcher,
+    createRouteMatches,
+    joinPathname
+} from '../src/matcher';
 import type { RouteConfirmHook } from '../src/types';
 
 const BASE_URL = new URL('https://www.esmx.dev');
@@ -1819,5 +1823,159 @@ describe('createMatcher', () => {
         assert.equal(result.matches.length, 1);
         assert.equal(result.matches[0].component, 'CatchAllPage');
         assert.deepEqual(result.params.rest, ['anything', 'else']);
+    });
+});
+
+describe('requireIndex', () => {
+    test('requireIndex: true with no index child route - parent path does not match', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true,
+                children: [
+                    { path: 'a', component: 'AaComponent' },
+                    { path: 'b', component: 'AbComponent' },
+                    { path: 'c', component: 'AcComponent' }
+                ]
+            }
+        ]);
+
+        const result = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 0);
+    });
+
+    test('requireIndex: true with path: "" index child route - parent path matches', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true,
+                children: [
+                    { path: '', component: 'IndexComponent' },
+                    { path: 'a', component: 'AaComponent' }
+                ]
+            }
+        ]);
+
+        const result = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 2);
+        assert.equal(result.matches[0].path, '/A');
+        assert.equal(result.matches[1].path, '');
+    });
+
+    test('requireIndex: true with index child route - child paths match normally', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true,
+                children: [
+                    { path: '', component: 'IndexComponent' },
+                    { path: 'a', component: 'AaComponent' }
+                ]
+            }
+        ]);
+
+        const result = matcher(new URL('/A/a', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 2);
+        assert.equal(result.matches[0].path, '/A');
+        assert.equal(result.matches[1].path, 'a');
+    });
+
+    test('requireIndex: false - parent path matches even without index child', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: false,
+                children: [{ path: 'a', component: 'AaComponent' }]
+            }
+        ]);
+
+        const result = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 1);
+        assert.equal(result.matches[0].path, '/A');
+    });
+
+    test('no requireIndex (undefined) - backward compatible, parent self-matches', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                children: [{ path: 'a', component: 'AaComponent' }]
+            }
+        ]);
+
+        const result = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 1);
+        assert.equal(result.matches[0].path, '/A');
+    });
+
+    test('requireIndex: true with no children - matches normally (self-match allowed)', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true
+            }
+        ]);
+
+        const result = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 1);
+        assert.equal(result.matches[0].path, '/A');
+    });
+
+    test('nested requireIndex - both parent and child requireIndex: true', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true,
+                children: [
+                    {
+                        path: 'b',
+                        requireIndex: true,
+                        children: [{ path: 'c', component: 'BcComponent' }]
+                    }
+                ]
+            }
+        ]);
+
+        // /A does not match (no index child)
+        const result1 = matcher(new URL('/A', BASE_URL), BASE_URL);
+        assert.equal(result1.matches.length, 0);
+
+        // /A/b does not match (no index child for /A/b)
+        const result2 = matcher(new URL('/A/b', BASE_URL), BASE_URL);
+        assert.equal(result2.matches.length, 0);
+
+        // /A/b/c matches
+        const result3 = matcher(new URL('/A/b/c', BASE_URL), BASE_URL);
+        assert.equal(result3.matches.length, 3);
+        assert.equal(result3.matches[0].path, '/A');
+        assert.equal(result3.matches[1].path, 'b');
+        assert.equal(result3.matches[2].path, 'c');
+    });
+
+    test('requireIndex: true - non-matching child path does not match parent', () => {
+        const matcher = createMatcher([
+            {
+                path: '/A',
+                requireIndex: true,
+                children: [
+                    { path: 'a', component: 'AaComponent' },
+                    { path: 'b', component: 'AbComponent' }
+                ]
+            }
+        ]);
+
+        const result = matcher(new URL('/A/f', BASE_URL), BASE_URL);
+        assert.equal(result.matches.length, 0);
+    });
+
+    test('requireIndex default value is false in RouteParsedConfig', () => {
+        const routes = [{ path: '/test' }];
+        const parsed = createRouteMatches(routes);
+        assert.equal(parsed[0].requireIndex, false);
+    });
+
+    test('requireIndex value is preserved in RouteParsedConfig', () => {
+        const routes = [{ path: '/test', requireIndex: true }];
+        const parsed = createRouteMatches(routes);
+        assert.equal(parsed[0].requireIndex, true);
     });
 });

--- a/packages/router/tests/route.test.ts
+++ b/packages/router/tests/route.test.ts
@@ -2468,4 +2468,74 @@ describe('🔍 Route Class Depth Test - Missing Scenario Supplement', () => {
             expect(route.url.pathname).toBe('/app/user/1000/detail');
         });
     });
+
+    describe('requireIndex integration', () => {
+        it('should not match parent route when requireIndex: true and no index child', () => {
+            const options = createOptions({
+                routes: [
+                    {
+                        path: '/A',
+                        requireIndex: true,
+                        children: [
+                            { path: 'a', component: 'AaComponent' },
+                            { path: 'b', component: 'AbComponent' }
+                        ]
+                    }
+                ]
+            });
+
+            const route = new Route({
+                options,
+                toType: RouteType.push,
+                toInput: '/A'
+            });
+
+            expect(route.matched.length).toBe(0);
+        });
+
+        it('should match parent route with index child when requireIndex: true', () => {
+            const options = createOptions({
+                routes: [
+                    {
+                        path: '/A',
+                        requireIndex: true,
+                        children: [
+                            { path: '', component: 'IndexComponent' },
+                            { path: 'a', component: 'AaComponent' }
+                        ]
+                    }
+                ]
+            });
+
+            const route = new Route({
+                options,
+                toType: RouteType.push,
+                toInput: '/A'
+            });
+
+            expect(route.matched.length).toBe(2);
+            expect(route.matched[0].path).toBe('/A');
+            expect(route.matched[1].path).toBe('');
+        });
+
+        it('should match parent route without requireIndex (backward compatible)', () => {
+            const options = createOptions({
+                routes: [
+                    {
+                        path: '/A',
+                        children: [{ path: 'a', component: 'AaComponent' }]
+                    }
+                ]
+            });
+
+            const route = new Route({
+                options,
+                toType: RouteType.push,
+                toInput: '/A'
+            });
+
+            expect(route.matched.length).toBe(1);
+            expect(route.matched[0].path).toBe('/A');
+        });
+    });
 });

--- a/packages/router/tests/router-resolve.test.ts
+++ b/packages/router/tests/router-resolve.test.ts
@@ -520,4 +520,72 @@ describe('Router.resolve method tests', () => {
             testRouter.destroy();
         });
     });
+
+    describe('requireIndex', () => {
+        test('should return empty matched when requireIndex: true and no index child', () => {
+            const router = new Router({
+                mode: RouterMode.memory,
+                base: new URL('http://localhost:3000/'),
+                routes: [
+                    {
+                        path: '/A',
+                        requireIndex: true,
+                        children: [
+                            { path: 'a', component: 'AaComponent' },
+                            { path: 'b', component: 'AbComponent' }
+                        ]
+                    }
+                ]
+            });
+
+            const route = router.resolve('/A');
+            expect(route.matched.length).toBe(0);
+            expect(route.config).toBeNull();
+
+            router.destroy();
+        });
+
+        test('should match with index child when requireIndex: true', () => {
+            const router = new Router({
+                mode: RouterMode.memory,
+                base: new URL('http://localhost:3000/'),
+                routes: [
+                    {
+                        path: '/A',
+                        requireIndex: true,
+                        children: [
+                            { path: '', component: 'IndexComponent' },
+                            { path: 'a', component: 'AaComponent' }
+                        ]
+                    }
+                ]
+            });
+
+            const route = router.resolve('/A');
+            expect(route.matched.length).toBe(2);
+            expect(route.matched[0].path).toBe('/A');
+            expect(route.matched[1].path).toBe('');
+
+            router.destroy();
+        });
+
+        test('should match parent self without requireIndex (backward compatible)', () => {
+            const router = new Router({
+                mode: RouterMode.memory,
+                base: new URL('http://localhost:3000/'),
+                routes: [
+                    {
+                        path: '/A',
+                        children: [{ path: 'a', component: 'AaComponent' }]
+                    }
+                ]
+            });
+
+            const route = router.resolve('/A');
+            expect(route.matched.length).toBe(1);
+            expect(route.matched[0].path).toBe('/A');
+
+            router.destroy();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Add `requireIndex` property to `RouteConfig` to control parent route self-matching behavior when child routes exist but none match.

## Behavior

| Scenario | `requireIndex: false` (default) | `requireIndex: true` |
|----------|------|------|
| Access `/A`, has children but no index child | Parent self-matches | **No match** |
| Access `/A`, has children with `path: ""` index child | Matches | Matches |
| Access `/A/a`, child route matches | Matches | Matches |
| Access `/A/f`, no child matches | No match | No match |
| Access `/A`, `requireIndex: true` but no children | Self-match allowed | Self-match allowed |

## Changes

- **`types.ts`**: Add `requireIndex?: boolean` to `RouteConfig` with JSDoc; Add `requireIndex: boolean` (non-optional) to `RouteParsedConfig`
- **`matcher.ts`**: Add `requireIndex` skip logic in `collectMatchingRoutes`; Add explicit default `route.requireIndex ?? false` in `createRouteMatches`
- **Tests**: 15 new test cases across 3 files (9 matcher + 3 route + 3 router-resolve)

## Backward Compatibility

✅ Fully backward compatible — default value is `false`, existing behavior unchanged when `requireIndex` is not set.