### PR TITLE
fix(import): add default export for builtin modules in Bun

### DIFF
--- a/packages/import/src/import-vm.ts
+++ b/packages/import/src/import-vm.ts
@@ -60,11 +60,20 @@ export function createVmImport(baseURL: URL, importMap: ImportMap = {}) {
         if (isBuiltin(specifier)) {
             const nodeModule = requireSync(specifier);
             const keys = Object.keys(nodeModule);
+            const hasDefault = keys.includes('default');
+            if (!hasDefault) {
+                keys.push('default');
+            }
             const module = new vm.SyntheticModule(
                 keys,
                 function evaluateCallback() {
                     keys.forEach((key) => {
-                        this.setExport(key, nodeModule[key]);
+                        this.setExport(
+                            key,
+                            key === 'default' && !hasDefault
+                                ? nodeModule
+                                : nodeModule[key]
+                        );
                     });
                 },
                 {


### PR DESCRIPTION
## Problem

Bun's `require('node:xxx')` returns CommonJS modules without `'default'` property, while Node.js includes it. This caused `import path from "node:path"` to fail with `Missing 'default' export` when running under Bun.

## Solution

Add synthetic `'default'` export for builtin modules when missing, using the module itself as the default value. This aligns Bun behavior with Node.js.

## Changes

- `packages/import/src/import-vm.ts`: detect missing `default` export and inject it

## Testing

- [x] All 41 existing tests pass (Node.js)
- [x] Verified with Bun 1.3.13:
  - Basic module loading
  - Module dependencies
  - Circular references
  - Builtin default import (`import path from "node:path"`)
  - Builtin named import (`import { join } from "node:path"`)
  - Self-reference
  - Dynamic imports