### PR TITLE
fix(examples): JSON-LD on every hub page + single <html lang>

### DIFF
--- a/examples/micro-app/ssr-micro-hub/src/entry.server.ts
+++ b/examples/micro-app/ssr-micro-hub/src/entry.server.ts
@@ -47,7 +47,7 @@ export default async (rc: RenderContext) => {
     });
 
     rc.html = `<!DOCTYPE html>
-<html lang="${locale}"${htmlAttrs}>
+<html${htmlAttrs}>
 <head>
     <link rel="icon" href="/logo.svg" type="image/svg+xml">
     ${headTags}

--- a/examples/micro-app/ssr-micro-shared/src/seo.ts
+++ b/examples/micro-app/ssr-micro-shared/src/seo.ts
@@ -34,6 +34,64 @@ function localizedUrl(lang: string, path: string): string {
     return path === '/' ? `${SITE_ORIGIN}/` : `${SITE_ORIGIN}${path}`;
 }
 
+/** The page's primary structured-data entity, mirroring the docs' TechArticle. */
+function webPageLd(
+    canonical: string,
+    title: string,
+    description: string,
+    lang: string
+): Record<string, unknown> {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: title,
+        description,
+        url: canonical,
+        inLanguage: lang,
+        isPartOf: {
+            '@type': 'WebSite',
+            name: SITE_NAME,
+            url: `${SITE_ORIGIN}/`
+        },
+        primaryImageOfPage: { '@type': 'ImageObject', url: OG_IMAGE },
+        publisher: {
+            '@type': 'Organization',
+            name: SITE_NAME,
+            url: SITE_ORIGIN
+        }
+    };
+}
+
+/**
+ * BreadcrumbList from the locale-agnostic path segments (Home → Demo, …).
+ * Returns `[]` for the home page, where a single-item breadcrumb adds nothing.
+ */
+function breadcrumbLd(lang: string, path: string): Record<string, unknown>[] {
+    const segments = path.split('/').filter(Boolean);
+    if (segments.length === 0) return [];
+    const items = [{ name: 'Home', url: localizedUrl(lang, '/') }];
+    let acc = '';
+    for (const segment of segments) {
+        acc += `/${segment}`;
+        const name = segment
+            .replace(/-/g, ' ')
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+        items.push({ name, url: localizedUrl(lang, `${acc}/`) });
+    }
+    return [
+        {
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: items.map((item, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: item.name,
+                item: item.url
+            }))
+        }
+    ];
+}
+
 export function buildSeoHead(
     router: Router,
     options: SeoOptions
@@ -45,6 +103,15 @@ export function buildSeoHead(
     const canonical = localizedUrl(lang, path);
     const enUrl = localizedUrl('en', path);
     const zhUrl = localizedUrl('zh', path);
+
+    // Every page carries a primary entity (WebPage) + breadcrumb, then any
+    // page-specific nodes the caller adds (e.g. the landing's Organization /
+    // WebSite / SoftwareApplication) — consistent with the docs' SeoHead.
+    const structuredData = [
+        webPageLd(canonical, title, description, lang),
+        ...breadcrumbLd(lang, path),
+        ...(jsonLd ?? [])
+    ];
 
     return {
         title,
@@ -69,7 +136,7 @@ export function buildSeoHead(
             { name: 'twitter:description', content: description },
             { name: 'twitter:image', content: OG_IMAGE }
         ],
-        script: (jsonLd ?? []).map((entry) => ({
+        script: structuredData.map((entry) => ({
             type: 'application/ld+json',
             innerHTML: JSON.stringify(entry)
         }))

--- a/examples/micro-app/ssr-micro-shared/src/seo.ts
+++ b/examples/micro-app/ssr-micro-shared/src/seo.ts
@@ -114,6 +114,10 @@ export function buildSeoHead(
     ];
 
     return {
+        // Single source of truth for the document language; the server shell
+        // renders `<html${htmlAttrs}>` with no hardcoded lang, so this is the
+        // only `lang` attribute and it tracks the URL locale.
+        htmlAttrs: { lang },
         title,
         link: [
             { rel: 'canonical', href: canonical },


### PR DESCRIPTION
Follow-up to #297, which was squash-merged before these two fixes landed — so the deployed hub framework/demo pages currently have **no JSON-LD** and a **duplicated `<html lang>`**.

## Fixes

1. **JSON-LD parity** — `buildSeoHead` now always emits a primary `WebPage` entity + `BreadcrumbList` (skipped on the home page), with page-specific nodes appended. Brings the hub in line with the docs (`TechArticle` + `BreadcrumbList`): every page on the site now has structured data.
   - landing → `WebPage` + `Organization` + `WebSite` + `SoftwareApplication`
   - demo + all 9 framework pages (en/zh) → `WebPage` + `BreadcrumbList`
2. **`<html lang>`** — the shell hardcoded `lang="${locale}"` while unhead also injected a default `lang="en"`, producing `<html lang="zh" lang="en">`. unhead is now the single source (`htmlAttrs.lang` = URL locale); the shell renders `<html${htmlAttrs}>`.

## Verification

- `/html/` (and all hub pages) now carry 2 JSON-LD blocks (WebPage + BreadcrumbList), valid JSON
- Every hub page has exactly one `<html lang>` with the correct value (en at root, zh under /zh)
- 11 micro-app packages build clean