### PR TITLE
test(integration): add smoke tests for framework bundler integrations

### DIFF
--- a/packages/rsbuild-react/tests/index.test.ts
+++ b/packages/rsbuild-react/tests/index.test.ts
@@ -1,0 +1,50 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createRsbuildApp } = vi.hoisted(() => ({
+    createRsbuildApp: vi.fn(async (..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/rsbuild', () => ({ createRsbuildApp }));
+
+import { createRsbuildReactApp } from '../src/index';
+
+const esmx = { isProd: false } as unknown as Esmx;
+
+function lastOptions() {
+    return createRsbuildApp.mock.calls.at(-1)?.[1] as {
+        config?: (context: { config: { plugins: unknown[] } }) => void;
+    };
+}
+
+describe('createRsbuildReactApp', () => {
+    test('delegates to createRsbuildApp with the same esmx instance', async () => {
+        createRsbuildApp.mockClear();
+
+        await createRsbuildReactApp(esmx);
+
+        expect(createRsbuildApp).toHaveBeenCalledTimes(1);
+        expect(createRsbuildApp.mock.calls[0][0]).toBe(esmx);
+    });
+
+    test('injects the React plugin through the config hook', async () => {
+        createRsbuildApp.mockClear();
+
+        await createRsbuildReactApp(esmx);
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(context.config.plugins.length).toBeGreaterThan(0);
+    });
+
+    test('preserves the user-supplied config hook', async () => {
+        createRsbuildApp.mockClear();
+        const userConfig = vi.fn();
+
+        await createRsbuildReactApp(esmx, { config: userConfig });
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(userConfig).toHaveBeenCalledWith(context);
+    });
+});

--- a/packages/rsbuild-vue/tests/index.test.ts
+++ b/packages/rsbuild-vue/tests/index.test.ts
@@ -1,0 +1,77 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createRsbuildApp } = vi.hoisted(() => ({
+    createRsbuildApp: vi.fn(async (..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/rsbuild', () => ({ createRsbuildApp }));
+
+import { createRsbuildVueApp } from '../src/index';
+
+const esmx = { isProd: false } as unknown as Esmx;
+
+function lastOptions() {
+    return createRsbuildApp.mock.calls.at(-1)?.[1] as {
+        config?: (context: {
+            buildTarget: string;
+            config: { plugins: unknown[]; tools?: Record<string, unknown> };
+        }) => void;
+    };
+}
+
+function makeContext(buildTarget: string) {
+    return {
+        buildTarget,
+        config: { plugins: [] as unknown[], tools: {} as Record<string, any> }
+    };
+}
+
+describe('createRsbuildVueApp', () => {
+    test('delegates to createRsbuildApp with the same esmx instance', async () => {
+        createRsbuildApp.mockClear();
+
+        await createRsbuildVueApp(esmx);
+
+        expect(createRsbuildApp).toHaveBeenCalledTimes(1);
+        expect(createRsbuildApp.mock.calls[0][0]).toBe(esmx);
+    });
+
+    test('injects the Vue plugin through the config hook', async () => {
+        createRsbuildApp.mockClear();
+
+        await createRsbuildVueApp(esmx);
+        const context = makeContext('client');
+        lastOptions().config?.(context);
+
+        expect(context.config.plugins.length).toBeGreaterThan(0);
+    });
+
+    test('aliases vue$ to the runtime build via bundlerChain', async () => {
+        createRsbuildApp.mockClear();
+
+        await createRsbuildVueApp(esmx);
+        const context = makeContext('server');
+        lastOptions().config?.(context);
+
+        const set = vi.fn().mockReturnThis();
+        const chain = { resolve: { alias: { set } } };
+        context.config.tools.bundlerChain(chain, {});
+
+        expect(set).toHaveBeenCalledWith(
+            'vue$',
+            expect.stringContaining('vue.runtime')
+        );
+    });
+
+    test('preserves the user-supplied config hook', async () => {
+        createRsbuildApp.mockClear();
+        const userConfig = vi.fn();
+
+        await createRsbuildVueApp(esmx, { config: userConfig });
+        const context = makeContext('client');
+        lastOptions().config?.(context);
+
+        expect(userConfig).toHaveBeenCalledWith(context);
+    });
+});

--- a/packages/rspack-react/tests/react.test.ts
+++ b/packages/rspack-react/tests/react.test.ts
@@ -1,0 +1,111 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createRspackHtmlApp } = vi.hoisted(() => ({
+    createRspackHtmlApp: vi.fn((..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/rspack', () => ({
+    createRspackHtmlApp,
+    rspack: { DefinePlugin: class DefinePlugin {} },
+    RSPACK_LOADER: { cssLoader: 'css-loader' }
+}));
+
+import { createRspackReactApp } from '../src/index';
+
+// A fluent recorder that returns itself for any property/call, capturing every
+// method invocation so the chain hook can run without a real webpack-chain.
+function createChainRecorder() {
+    const calls: { name: string; args: unknown[] }[] = [];
+    const make = (name: string): any =>
+        new Proxy(
+            (...args: unknown[]) => {
+                calls.push({ name, args });
+                return make('root');
+            },
+            {
+                get: (_t, prop) =>
+                    typeof prop === 'string' ? make(prop) : undefined
+            }
+        );
+    return { chain: make('root'), calls };
+}
+
+function called(
+    calls: { name: string; args: unknown[] }[],
+    name: string,
+    arg?: unknown
+) {
+    return calls.some(
+        (c) => c.name === name && (arg === undefined || c.args[0] === arg)
+    );
+}
+
+function runChain(buildTarget: string, isProd: boolean) {
+    createRspackHtmlApp.mockClear();
+    const userChain = vi.fn();
+    createRspackReactApp({ isProd } as unknown as Esmx, { chain: userChain });
+
+    const options = createRspackHtmlApp.mock.calls[0][1] as {
+        chain: (context: unknown) => void;
+    };
+    const { chain, calls } = createChainRecorder();
+    const context = { chain, buildTarget, esmx: { isProd } };
+    options.chain(context);
+
+    return { calls, userChain, context };
+}
+
+describe('createRspackReactApp', () => {
+    test('delegates to createRspackHtmlApp', () => {
+        createRspackHtmlApp.mockClear();
+
+        createRspackReactApp({ isProd: false } as unknown as Esmx);
+
+        expect(createRspackHtmlApp).toHaveBeenCalledTimes(1);
+    });
+
+    test('registers the tsx/jsx extensions and loader rule', () => {
+        const { calls } = runChain('client', false);
+
+        expect(called(calls, 'add', '.tsx')).toBe(true);
+        expect(called(calls, 'add', '.jsx')).toBe(true);
+        expect(called(calls, 'rule', 'react-tsx')).toBe(true);
+    });
+
+    test('enables React Refresh only for client dev builds', () => {
+        expect(
+            called(runChain('client', false).calls, 'plugin', 'react-refresh')
+        ).toBe(true);
+        expect(
+            called(runChain('server', false).calls, 'plugin', 'react-refresh')
+        ).toBe(false);
+        expect(
+            called(runChain('client', true).calls, 'plugin', 'react-refresh')
+        ).toBe(false);
+    });
+
+    test('defines the React env for client builds', () => {
+        expect(
+            called(
+                runChain('client', false).calls,
+                'plugin',
+                'define-react-env'
+            )
+        ).toBe(true);
+        expect(
+            called(
+                runChain('server', false).calls,
+                'plugin',
+                'define-react-env'
+            )
+        ).toBe(false);
+    });
+
+    test('preserves the user-supplied chain hook', () => {
+        const { userChain, context } = runChain('client', false);
+
+        expect(userChain).toHaveBeenCalledTimes(1);
+        expect(userChain.mock.calls[0][0]).toBe(context);
+    });
+});

--- a/packages/rspack-vue/tests/vue.test.ts
+++ b/packages/rspack-vue/tests/vue.test.ts
@@ -1,0 +1,170 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createRspackHtmlApp } = vi.hoisted(() => ({
+    createRspackHtmlApp: vi.fn((..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/rspack', () => ({
+    createRspackHtmlApp,
+    rspack: { DefinePlugin: class DefinePlugin {} },
+    RSPACK_LOADER: { cssLoader: 'css-loader' }
+}));
+
+import { createRspackVue2App, createRspackVue3App } from '../src/index';
+
+// A fluent recorder that returns itself for any property/call, capturing every
+// method invocation so the chain hook can run without a real webpack-chain.
+function createChainRecorder() {
+    const calls: { name: string; args: unknown[] }[] = [];
+    const make = (name: string): any =>
+        new Proxy(
+            (...args: unknown[]) => {
+                calls.push({ name, args });
+                return make('root');
+            },
+            {
+                get: (_t, prop) =>
+                    typeof prop === 'string' ? make(prop) : undefined
+            }
+        );
+    return { chain: make('root'), calls };
+}
+
+function called(
+    calls: { name: string; args: unknown[] }[],
+    name: string,
+    arg?: unknown
+) {
+    return calls.some(
+        (c) => c.name === name && (arg === undefined || c.args[0] === arg)
+    );
+}
+
+const COMMAND = { dev: 'dev' };
+
+function runChain(
+    factory: typeof createRspackVue3App,
+    esmx: Record<string, unknown>,
+    buildTarget: string
+) {
+    createRspackHtmlApp.mockClear();
+    const userChain = vi.fn();
+    factory({ ...esmx, COMMAND } as unknown as Esmx, { chain: userChain });
+
+    const options = createRspackHtmlApp.mock.calls[0][1] as {
+        chain: (context: unknown) => void;
+    };
+    const { chain, calls } = createChainRecorder();
+    const context = { chain, buildTarget, esmx: { ...esmx, COMMAND } };
+    options.chain(context);
+
+    return { calls, userChain, context };
+}
+
+describe('createRspackVue3App', () => {
+    test('delegates to createRspackHtmlApp', () => {
+        createRspackHtmlApp.mockClear();
+
+        createRspackVue3App({ isProd: false, COMMAND } as unknown as Esmx);
+
+        expect(createRspackHtmlApp).toHaveBeenCalledTimes(1);
+    });
+
+    test('registers the .vue extension, loader and rule', () => {
+        const { calls } = runChain(
+            createRspackVue3App,
+            { isProd: false },
+            'client'
+        );
+
+        expect(called(calls, 'add', '.vue')).toBe(true);
+        expect(called(calls, 'plugin', 'vue-loader')).toBe(true);
+        expect(called(calls, 'rule', 'vue')).toBe(true);
+    });
+
+    test('aliases vue$ to a runtime build', () => {
+        const { calls } = runChain(
+            createRspackVue3App,
+            { isProd: false },
+            'client'
+        );
+
+        const alias = calls.find(
+            (c) => c.name === 'set' && c.args[0] === 'vue$'
+        );
+        expect(alias?.args[1]).toEqual(expect.stringContaining('vue.runtime'));
+    });
+
+    test('defines the Vue env for client builds', () => {
+        expect(
+            called(
+                runChain(createRspackVue3App, { isProd: false }, 'client')
+                    .calls,
+                'plugin',
+                'define-vue-env'
+            )
+        ).toBe(true);
+        expect(
+            called(
+                runChain(createRspackVue3App, { isProd: false }, 'server')
+                    .calls,
+                'plugin',
+                'define-vue-env'
+            )
+        ).toBe(false);
+    });
+
+    test('preserves the user-supplied chain hook', () => {
+        const { userChain, context } = runChain(
+            createRspackVue3App,
+            { isProd: false },
+            'client'
+        );
+
+        expect(userChain).toHaveBeenCalledTimes(1);
+        expect(userChain.mock.calls[0][0]).toBe(context);
+    });
+});
+
+describe('createRspackVue2App', () => {
+    test('registers the vue loader and rule', () => {
+        const { calls } = runChain(
+            createRspackVue2App,
+            { isProd: false, command: 'build' },
+            'client'
+        );
+
+        expect(called(calls, 'plugin', 'vue-loader')).toBe(true);
+        expect(called(calls, 'rule', 'vue')).toBe(true);
+    });
+
+    test('aliases vue$ to the Vue 2 runtime build', () => {
+        const { calls } = runChain(
+            createRspackVue2App,
+            { isProd: false, command: 'build' },
+            'client'
+        );
+
+        const alias = calls.find(
+            (c) => c.name === 'set' && c.args[0] === 'vue$'
+        );
+        expect(alias?.args[1]).toBe('vue/dist/vue.runtime.esm.js');
+    });
+
+    test('adds the dev HMR loader for client dev builds', () => {
+        const dev = runChain(
+            createRspackVue2App,
+            { isProd: false, command: 'dev' },
+            'client'
+        );
+        const build = runChain(
+            createRspackVue2App,
+            { isProd: false, command: 'build' },
+            'client'
+        );
+
+        expect(called(dev.calls, 'use', 'vue2-dev-hmr-loader')).toBe(true);
+        expect(called(build.calls, 'use', 'vue2-dev-hmr-loader')).toBe(false);
+    });
+});

--- a/packages/rspack-vue/vitest.config.ts
+++ b/packages/rspack-vue/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+
+// vue-app.ts and the loader entry modules call `import.meta.resolve(...)` —
+// some at module top level. Vitest's Vite SSR transform rewrites `import.meta`
+// to `__vite_ssr_import_meta__`, which lacks `resolve`, so those modules throw
+// on import. Replace `import.meta.resolve` with a createRequire-based shim
+// BEFORE Vite's transform runs (enforce: 'pre'), keeping the source untouched.
+export default defineConfig({
+    plugins: [
+        {
+            name: 'esmx-test-import-meta-resolve',
+            enforce: 'pre',
+            transform(code, id) {
+                if (!id.includes('rspack-vue/src')) return;
+                if (!code.includes('import.meta.resolve')) return;
+
+                const banner = [
+                    "import { createRequire as __esmxCreateRequire } from 'node:module';",
+                    "import { pathToFileURL as __esmxPathToFileURL } from 'node:url';",
+                    'const __esmxRequire = __esmxCreateRequire(import.meta.url);',
+                    'const __esmxResolve = (spec) =>',
+                    "    typeof spec === 'string' && spec.startsWith('file:')",
+                    '        ? spec',
+                    '        : __esmxPathToFileURL(__esmxRequire.resolve(spec)).href;',
+                    ''
+                ].join('\n');
+
+                return {
+                    code:
+                        banner +
+                        code.replace(/import\.meta\.resolve/g, '__esmxResolve'),
+                    map: null
+                };
+            }
+        }
+    ]
+});

--- a/packages/vite-react/tests/index.test.ts
+++ b/packages/vite-react/tests/index.test.ts
@@ -1,0 +1,50 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createViteApp } = vi.hoisted(() => ({
+    createViteApp: vi.fn(async (..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/vite', () => ({ createViteApp }));
+
+import { createViteReactApp } from '../src/index';
+
+const esmx = { isProd: false } as unknown as Esmx;
+
+function lastOptions() {
+    return createViteApp.mock.calls.at(-1)?.[1] as {
+        config?: (context: { config: { plugins: unknown[] } }) => void;
+    };
+}
+
+describe('createViteReactApp', () => {
+    test('delegates to createViteApp with the same esmx instance', async () => {
+        createViteApp.mockClear();
+
+        await createViteReactApp(esmx);
+
+        expect(createViteApp).toHaveBeenCalledTimes(1);
+        expect(createViteApp.mock.calls[0][0]).toBe(esmx);
+    });
+
+    test('injects the React plugin through the config hook', async () => {
+        createViteApp.mockClear();
+
+        await createViteReactApp(esmx);
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(context.config.plugins.length).toBeGreaterThan(0);
+    });
+
+    test('preserves the user-supplied config hook', async () => {
+        createViteApp.mockClear();
+        const userConfig = vi.fn();
+
+        await createViteReactApp(esmx, { config: userConfig });
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(userConfig).toHaveBeenCalledWith(context);
+    });
+});

--- a/packages/vite-vue/tests/index.test.ts
+++ b/packages/vite-vue/tests/index.test.ts
@@ -1,0 +1,50 @@
+import type { Esmx } from '@esmx/core';
+import { describe, expect, test, vi } from 'vitest';
+
+const { createViteApp } = vi.hoisted(() => ({
+    createViteApp: vi.fn(async (..._args: unknown[]) => ({}) as never)
+}));
+
+vi.mock('@esmx/vite', () => ({ createViteApp }));
+
+import { createViteVueApp } from '../src/index';
+
+const esmx = { isProd: false } as unknown as Esmx;
+
+function lastOptions() {
+    return createViteApp.mock.calls.at(-1)?.[1] as {
+        config?: (context: { config: { plugins: unknown[] } }) => void;
+    };
+}
+
+describe('createViteVueApp', () => {
+    test('delegates to createViteApp with the same esmx instance', async () => {
+        createViteApp.mockClear();
+
+        await createViteVueApp(esmx);
+
+        expect(createViteApp).toHaveBeenCalledTimes(1);
+        expect(createViteApp.mock.calls[0][0]).toBe(esmx);
+    });
+
+    test('injects the Vue plugin through the config hook', async () => {
+        createViteApp.mockClear();
+
+        await createViteVueApp(esmx);
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(context.config.plugins.length).toBeGreaterThan(0);
+    });
+
+    test('preserves the user-supplied config hook', async () => {
+        createViteApp.mockClear();
+        const userConfig = vi.fn();
+
+        await createViteVueApp(esmx, { config: userConfig });
+        const context = { config: { plugins: [] as unknown[] } };
+        lastOptions().config?.(context);
+
+        expect(userConfig).toHaveBeenCalledWith(context);
+    });
+});


### PR DESCRIPTION
## Summary
The six framework integration packages shipped with **zero tests**. This adds smoke-level coverage for each.

| Package | Tests |
|---|---|
| `@esmx/vite-react` | 3 |
| `@esmx/vite-vue` | 3 |
| `@esmx/rsbuild-react` | 3 |
| `@esmx/rsbuild-vue` | 4 |
| `@esmx/rspack-react` | 5 |
| `@esmx/rspack-vue` | 8 |

**26 tests total, no source changes.**

## Approach
Each wrapper is a thin layer over a base app factory (`createViteApp` / `createRsbuildApp` / `createRspackHtmlApp`). The tests `vi.mock` the base factory, capture the options it receives, then drive the wrapper's `config`/`chain` hook to assert it:

1. **delegates** to the base factory with the same `esmx` instance,
2. **injects** its framework plugin (vite/rsbuild) or loader+rules (rspack) — including build-target-specific behavior like React Refresh / HMR only on client-dev, and the SSR `vue$` runtime alias,
3. **preserves** the user-supplied `config`/`chain` hook.

For the rspack packages a small fluent Proxy recorder stands in for webpack-chain so the chain hook runs without a real bundler.

`rspack-vue`'s loader modules call `import.meta.resolve` at top level, which vitest's Vite SSR transform rewrites to an unsupported `__vite_ssr_import_meta__.resolve`. A local `vitest.config.ts` shims it via `createRequire` in a pre-transform plugin — no source change.

## Verification
- `pnpm test` ✅ (full repo, all packages green)
- `pnpm lint:type` ✅
- `biome check` ✅