### PR TITLE
build(release): set publishConfig.access to public for all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,5 +100,8 @@
         "template",
         "public"
     ],
-    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5"
+    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/create-esmx/package.json
+++ b/packages/create-esmx/package.json
@@ -73,5 +73,8 @@
     "engines": {
         "node": ">=24"
     },
-    "homepage": "https://github.com/esmnext/esmx#readme"
+    "homepage": "https://github.com/esmnext/esmx#readme",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -72,5 +72,8 @@
     "gitHead": "2e16b175552400382913b445ae7e112b78c422f5",
     "engines": {
         "node": ">=24"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/pkg-wrapper/package.json
+++ b/packages/pkg-wrapper/package.json
@@ -57,5 +57,8 @@
         "src",
         "dist",
         "*.mjs"
-    ]
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/router-react/package.json
+++ b/packages/router-react/package.json
@@ -94,5 +94,8 @@
     "gitHead": "3e692857ccb65e7d1fdf689e30eb5d935e8bda77",
     "engines": {
         "node": ">=24"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/router-vue/package.json
+++ b/packages/router-vue/package.json
@@ -94,5 +94,8 @@
     "gitHead": "3e692857ccb65e7d1fdf689e30eb5d935e8bda77",
     "engines": {
         "node": ">=24"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -86,5 +86,8 @@
     "gitHead": "3e692857ccb65e7d1fdf689e30eb5d935e8bda77",
     "engines": {
         "node": ">=24"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/rsbuild-react/package.json
+++ b/packages/rsbuild-react/package.json
@@ -12,7 +12,14 @@
     },
     "template": "library-node",
     "license": "MIT",
-    "keywords": ["Rsbuild", "Rspack", "React", "Esmx", "SSR", "Module Linking"],
+    "keywords": [
+        "Rsbuild",
+        "Rspack",
+        "React",
+        "Esmx",
+        "SSR",
+        "Module Linking"
+    ],
     "scripts": {
         "lint:js": "biome check --write --no-errors-on-unmatched",
         "lint:css": "pnpm run lint:js",
@@ -53,5 +60,12 @@
     },
     "module": "dist/index.mjs",
     "types": "./dist/index.d.ts",
-    "files": ["src", "dist", "*.mjs"]
+    "files": [
+        "src",
+        "dist",
+        "*.mjs"
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/rsbuild-vue/package.json
+++ b/packages/rsbuild-vue/package.json
@@ -12,7 +12,14 @@
     },
     "template": "library-node",
     "license": "MIT",
-    "keywords": ["Rsbuild", "Rspack", "Vue", "Esmx", "SSR", "Module Linking"],
+    "keywords": [
+        "Rsbuild",
+        "Rspack",
+        "Vue",
+        "Esmx",
+        "SSR",
+        "Module Linking"
+    ],
     "scripts": {
         "lint:js": "biome check --write --no-errors-on-unmatched",
         "lint:css": "pnpm run lint:js",
@@ -52,5 +59,12 @@
     },
     "module": "dist/index.mjs",
     "types": "./dist/index.d.ts",
-    "files": ["src", "dist", "*.mjs"]
+    "files": [
+        "src",
+        "dist",
+        "*.mjs"
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -68,5 +68,8 @@
         "src",
         "dist",
         "*.mjs"
-    ]
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/rspack-react/package.json
+++ b/packages/rspack-react/package.json
@@ -79,5 +79,8 @@
         "template",
         "public"
     ],
-    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5"
+    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/rspack-vue/package.json
+++ b/packages/rspack-vue/package.json
@@ -92,5 +92,8 @@
         "template",
         "public"
     ],
-    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5"
+    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -112,5 +112,8 @@
         "template",
         "public"
     ],
-    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5"
+    "gitHead": "2e16b175552400382913b445ae7e112b78c422f5",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/vite-react/package.json
+++ b/packages/vite-react/package.json
@@ -12,7 +12,13 @@
     },
     "template": "library-node",
     "license": "MIT",
-    "keywords": ["Vite", "React", "Esmx", "SSR", "Module Linking"],
+    "keywords": [
+        "Vite",
+        "React",
+        "Esmx",
+        "SSR",
+        "Module Linking"
+    ],
     "scripts": {
         "lint:js": "biome check --write --no-errors-on-unmatched",
         "lint:css": "pnpm run lint:js",
@@ -53,5 +59,12 @@
     },
     "module": "dist/index.mjs",
     "types": "./dist/index.d.ts",
-    "files": ["src", "dist", "*.mjs"]
+    "files": [
+        "src",
+        "dist",
+        "*.mjs"
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/vite-vue/package.json
+++ b/packages/vite-vue/package.json
@@ -12,7 +12,13 @@
     },
     "template": "library-node",
     "license": "MIT",
-    "keywords": ["Vite", "Vue", "Esmx", "SSR", "Module Linking"],
+    "keywords": [
+        "Vite",
+        "Vue",
+        "Esmx",
+        "SSR",
+        "Module Linking"
+    ],
     "scripts": {
         "lint:js": "biome check --write --no-errors-on-unmatched",
         "lint:css": "pnpm run lint:js",
@@ -52,5 +58,12 @@
     },
     "module": "dist/index.mjs",
     "types": "./dist/index.d.ts",
-    "files": ["src", "dist", "*.mjs"]
+    "files": [
+        "src",
+        "dist",
+        "*.mjs"
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -65,5 +65,8 @@
         "src",
         "dist",
         "*.mjs"
-    ]
+    ],
+    "publishConfig": {
+        "access": "public"
+    }
 }


### PR DESCRIPTION
## Why

When publishing the monorepo with `lerna publish`, the newly added scoped packages would fail on their first publish:

- `@esmx/pkg-wrapper`
- `@esmx/vite`, `@esmx/vite-react`, `@esmx/vite-vue`
- `@esmx/rsbuild`, `@esmx/rsbuild-react`, `@esmx/rsbuild-vue`

npm treats scoped packages (`@esmx/*`) as `restricted` (private) on first publish. Without an explicit public access setting, the publish fails with `402 Payment Required`. Because lerna publishes in topological order, a failure on an early package (e.g. `@esmx/pkg-wrapper`) can interrupt the whole release and leave a partially-published state.

## What

Add `publishConfig.access: "public"` to all 16 packages for consistency. This is idempotent for the already-published packages and guarantees first-time publish of the new ones works.

Some files also show array reformatting (single-line → multi-line) from Biome's standard formatting.

## Test plan

- [ ] `pnpm build:packages` succeeds
- [ ] `pnpm release` publishes all packages to npm (`3.0.0-rc.118`)