### PR TITLE
fix(seo): stop duplicating hub HTML under /ssr-micro-hub/ (dup of root demo pages)

### DIFF
--- a/build/tasks/artifacts.mjs
+++ b/build/tasks/artifacts.mjs
@@ -48,7 +48,18 @@ export async function copyArtifacts() {
     for (const { name, path } of namespacedDirs) {
         const targetDir = join(config.outDir, name);
         mkdirSync(targetDir, { recursive: true });
-        cpSync(path, targetDir, { recursive: true });
+        // The hub is overlaid at the site root below, so its root-relative HTML
+        // pages (landing + each `/<framework>/` demo) already exist at the root.
+        // Copy only the hub's ASSETS to its `/ssr-micro-hub/` namespace — the
+        // root HTML loads its scripts/styles from there — and skip the HTML,
+        // which would otherwise duplicate every root page under
+        // `/ssr-micro-hub/*` (canonical-duplicate URLs Google indexed instead
+        // of the clean paths).
+        const filter =
+            name === 'ssr-micro-hub'
+                ? (src) => !src.endsWith('.html')
+                : undefined;
+        cpSync(path, targetDir, { recursive: true, filter });
         log.info(
             `Copied ${toDisplayPath(path)} to ${toDisplayPath(targetDir)}`
         );


### PR DESCRIPTION
## Problem (found via a live Google result)

Searching "Lit Micro-App" returned **`https://esmx.dev/ssr-micro-hub/lit/`** at #4 — the *namespaced duplicate* of the clean `/lit/` page.

The micro-app hub is both (a) overlaid at the site root (landing + each `/<framework>/` demo) and (b) copied to its `/ssr-micro-hub/` namespace so the root HTML can load its hashed scripts/styles from there. But the namespaced copy also carried the **HTML**, so every root demo page was duplicated under `/ssr-micro-hub/*` — **22 canonical-duplicate URLs** that ended up in the sitemap and got indexed/ranked instead of the clean paths.

(Same class of bug as the `/docs/*` duplicate fixed in #305, but the hub differs: its assets at `/ssr-micro-hub/src/*` are referenced by the root pages, so the directory can't simply be dropped.)

## Fix

In `build/tasks/artifacts.mjs`, copy only the hub's **assets** to `/ssr-micro-hub/` and skip its `.html` (via a `cpSync` filter). The root overlay already provides every HTML page; canonicals already point at the root paths; and the sitemap (derived from built HTML) drops the 22 duplicates automatically.

## Verification

- Unit-tested the `cpSync` filter: nested `*/index.html` skipped, `.mjs`/`.css` kept.
- To confirm on the preview after build: `/ssr-micro-hub/lit/` → 404, `/lit/` → 200 and still loads `/ssr-micro-hub/src/*` assets, sitemap has 0 `/ssr-micro-hub/` URLs.