### PR TITLE
fix(build): resolve nx allowBuilds placeholder so local pnpm build runs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,4 +27,4 @@ allowBuilds:
   puppeteer: false
   protobufjs: false
   less: false
-  nx: set this to true or false
+  nx: false


### PR DESCRIPTION
## Problem

`pnpm build` (the full `node ./build.mjs` pipeline) fails locally at the first step for any contributor on pnpm 11:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: nx@20.8.4
Error: Command failed with exit code 1: Command failed: pnpm i
  at execCommand (build/utils.mjs:46) ... initEnvironment (build/tasks/environment.mjs:25)
```

Root cause: `pnpm-workspace.yaml` `allowBuilds` had `nx: set this to true or false` — the literal placeholder pnpm writes when a dependency's build script is undecided. On pnpm 11 in an interactive shell this makes `pnpm i` **exit 1**, and `build.mjs`'s `execCommand` treats any non-zero exit as fatal. CI never hit it because CI mode (`CI=true`) downgrades ignored builds to a warning (exit 0).

## Fix

Set `nx: false`. nx's build script is not needed here — CI has always run with it ignored (including `lerna publish`), and it matches the other declined entries (core-js, puppeteer, …).

## Verification

- `pnpm i` → exit 0 (no ERR_PNPM_IGNORED_BUILDS)
- full `pnpm build` → completes, EXIT_CODE=0