### PR TITLE
fix(site): auto-version badge, dedup titles, fix broken code fences & hero spacing

### DIFF
--- a/examples/docs/src/components/SeoHead.tsx
+++ b/examples/docs/src/components/SeoHead.tsx
@@ -106,7 +106,13 @@ export default function SeoHead() {
 
     const suffix = page.frontmatter?.titleSuffix as string | undefined;
     const baseTitle = page.title || SITE_NAME;
-    const title = suffix ? `${baseTitle} - ${suffix}` : baseTitle;
+    // Compose `H1 - suffix`, but if the suffix already restates the H1 (many
+    // pages set titleSuffix to a phrase containing the heading), fall back to
+    // the suffix alone so the <title> doesn't repeat the same words twice.
+    const title =
+        suffix && !suffix.includes(baseTitle)
+            ? `${baseTitle} - ${suffix}`
+            : suffix || baseTitle;
     const description =
         page.description ||
         (page.frontmatter?.description as string | undefined) ||

--- a/examples/docs/src/en/api/core/render-context.md
+++ b/examples/docs/src/en/api/core/render-context.md
@@ -538,3 +538,4 @@ rc.html = `
     ${rc.modulePreload()}
   </body>
 `;
+```

--- a/examples/docs/src/en/guide/essentials/csr.md
+++ b/examples/docs/src/en/guide/essentials/csr.md
@@ -65,6 +65,7 @@ export default {
         );
     }
 } satisfies EsmxOptions;
+```
 
 ## Related
 

--- a/examples/docs/src/en/guide/router/react.md
+++ b/examples/docs/src/en/guide/router/react.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "React Integration — @esmx/router"
+titleSuffix: "@esmx/router"
 description: "Integrate @esmx/router with React using the micro-app pattern: mount, unmount, SSR via renderToString, custom hooks, a RouterLink equivalent, and examples."
 head:
   - - "meta"

--- a/examples/docs/src/en/guide/router/vue2.md
+++ b/examples/docs/src/en/guide/router/vue2.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "Vue 2 Integration — @esmx/router"
+titleSuffix: "@esmx/router"
 description: "Complete guide to integrating @esmx/router with Vue 2.7+ — plugin setup, Composition API and Options API usage, SSR, and full working examples."
 head:
   - - "meta"

--- a/examples/docs/src/en/guide/router/vue3.md
+++ b/examples/docs/src/en/guide/router/vue3.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "Vue 3 Integration — @esmx/router"
+titleSuffix: "@esmx/router"
 description: "Complete guide to integrating @esmx/router with Vue 3 — plugin setup, composables, SSR, RouterView, RouterLink, and full working examples."
 head:
   - - "meta"

--- a/examples/docs/src/en/llms.md
+++ b/examples/docs/src/en/llms.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "Using Esmx with an AI assistant"
+titleSuffix: "llms.txt Guide"
 description: "Single-file Esmx briefing for AI assistants: the package.json esmx module protocol, the esmx validate CLI loop, and legacy syntax. Feed it before coding."
 head:
   - - "meta"

--- a/examples/docs/src/zh/guide/router/react.md
+++ b/examples/docs/src/zh/guide/router/react.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "@esmx/router React 集成"
+titleSuffix: "@esmx/router"
 description: "完整的 @esmx/router 与 React 集成指南 — 涵盖微应用模式、renderToString SSR、自定义 hooks、RouterLink 组件及完整示例。"
 head:
   - - "meta"

--- a/examples/docs/src/zh/guide/router/vue2.md
+++ b/examples/docs/src/zh/guide/router/vue2.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "@esmx/router Vue 2 集成"
+titleSuffix: "@esmx/router"
 description: "完整的 @esmx/router 与 Vue 2.7+ 集成指南 — 涵盖插件配置、组合式 API 与选项式 API 用法、SSR 及完整示例。"
 head:
   - - "meta"

--- a/examples/docs/src/zh/guide/router/vue3.md
+++ b/examples/docs/src/zh/guide/router/vue3.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "@esmx/router Vue 3 集成"
+titleSuffix: "@esmx/router"
 description: "完整的 @esmx/router 与 Vue 3 集成指南 — 涵盖插件配置、组合式 API、SSR、RouterView、RouterLink 及完整示例。"
 head:
   - - "meta"

--- a/examples/docs/src/zh/llms.md
+++ b/examples/docs/src/zh/llms.md
@@ -1,5 +1,5 @@
 ---
-titleSuffix: "用 AI 助手开发 Esmx"
+titleSuffix: "llms.txt 指南"
 description: "Esmx 的 AI 单文件简报：模块协议、esmx validate 验证、遗留语法。让 Claude、Cursor、Copilot、Gemini 写 Esmx 代码前先读这页。"
 head:
   - - "meta"

--- a/examples/micro-app/ssr-micro-hub/src/landing-app.ts
+++ b/examples/micro-app/ssr-micro-hub/src/landing-app.ts
@@ -1,6 +1,7 @@
 import {
     BaseApp,
     buildSeoHead,
+    ESMX_VERSION,
     landingLd,
     localeFromPath,
     localePath,
@@ -107,9 +108,9 @@ export class LandingApp extends BaseApp {
             `<div class="hero-content">` +
             `<div class="hero-badge reveal">` +
             `<span class="hero-badge-dot"></span>` +
-            t(this.router, 'heroBadge') +
+            `v${ESMX_VERSION} ${t(this.router, 'heroBadge')}` +
             `</div>` +
-            `<h1 class="hero-title reveal reveal-delay-1">${t(this.router, 'heroTitleLead')}<span class="hero-title-gradient">${t(this.router, 'heroTitleGradient')}</span></h1>` +
+            `<h1 class="hero-title reveal reveal-delay-1">${t(this.router, 'heroTitleLead')} <span class="hero-title-gradient">${t(this.router, 'heroTitleGradient')}</span></h1>` +
             `<p class="hero-subtitle reveal reveal-delay-2">${t(this.router, 'heroSubtitle')}</p>` +
             `<div class="hero-actions reveal reveal-delay-3">` +
             `<a href="#quickstart" class="btn btn-primary">${t(this.router, 'heroBtnQuickstart')}<span aria-hidden="true">${ARROW_RIGHT_ICON}</span></a>` +
@@ -118,7 +119,7 @@ export class LandingApp extends BaseApp {
             `</div>` +
             `<div class="hero-trust reveal reveal-delay-4">` +
             `<span class="hero-trust-item"><span aria-hidden="true">${STAR_ICON}</span>GitHub</span>` +
-            `<span class="hero-trust-item">@esmx/core v3.0.0-rc.117</span>` +
+            `<span class="hero-trust-item">@esmx/core v${ESMX_VERSION}</span>` +
             `<span class="hero-trust-item">MIT License</span>` +
             `</div>` +
             `</div>` +

--- a/examples/micro-app/ssr-micro-shared/src/i18n.ts
+++ b/examples/micro-app/ssr-micro-shared/src/i18n.ts
@@ -32,7 +32,7 @@ const messages = {
         navQuickstart: 'Quick Start',
         navEcosystem: 'Ecosystem',
         navDocs: 'Docs',
-        heroBadge: 'v3.0.0-rc.117 Preview',
+        heroBadge: 'Preview',
         heroTitleLead: 'A Universal Rendering Framework',
         heroTitleGradient: 'Built on Native ESM',
         heroSubtitle:
@@ -136,7 +136,7 @@ const messages = {
         navQuickstart: '快速开始',
         navEcosystem: '生态',
         navDocs: '文档',
-        heroBadge: 'v3.0.0-rc.117 预览版',
+        heroBadge: '预览版',
         heroTitleLead: '基于原生 ESM 的',
         heroTitleGradient: '通用渲染框架',
         heroSubtitle:

--- a/examples/micro-app/ssr-micro-shared/src/index.ts
+++ b/examples/micro-app/ssr-micro-shared/src/index.ts
@@ -38,3 +38,4 @@ export {
 export type { SeoOptions } from './seo';
 export { buildSeoHead, landingLd, organizationLd } from './seo';
 export { getSsrStyles, setSsrStyles } from './ssr-styles';
+export { ESMX_VERSION } from './version';

--- a/examples/micro-app/ssr-micro-shared/src/version.ts
+++ b/examples/micro-app/ssr-micro-shared/src/version.ts
@@ -1,0 +1,9 @@
+import corePkg from '@esmx/core/package.json';
+
+/**
+ * The framework version, sourced from `@esmx/core`'s package.json so the site
+ * always reflects the released version (lerna bumps it) — no hardcoded strings
+ * to update by hand. Inlined at build time, so it is consistent across SSR and
+ * client hydration.
+ */
+export const ESMX_VERSION: string = corePkg.version;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,8 @@
         "./cli": {
             "import": "./dist/cli/cli.mjs",
             "types": "./dist/cli/cli.d.ts"
-        }
+        },
+        "./package.json": "./package.json"
     },
     "module": "dist/index.mjs",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
On-site polish — the quick, high-value fixes from the quality audit plus the version-badge request.

### Version badge now auto-tracks releases (was hardcoded rc.117)
- New `ESMX_VERSION` in `ssr-micro-shared`, sourced from `@esmx/core`'s `package.json` (added a `"./package.json"` export to `@esmx/core`). Inlined at build → consistent SSR/client, updates automatically every release (lerna bumps core).
- Homepage hero badge + `@esmx/core vX` trust item now use `ESMX_VERSION`; removed the hardcoded version from the `heroBadge` i18n strings.

### Rendering / correctness bugs
- **Hero `<h1>` missing space**: rendered "Framework**Built on** Native ESM" — added the space between the lead and gradient spans.
- **Two unclosed code fences** broke docs rendering: `en/api/core/render-context.md` (EOF) and `en/guide/essentials/csr.md` (its `## Related` section was swallowed into a code block). Both closed.

### Title de-duplication (SEO)
- **SeoHead guard**: `og:title`/`twitter:title` no longer repeat the H1 when `titleSuffix` already contains it (fixes the social title on ~all affected pages).
- **`<title>`** (rspress-native, from frontmatter): stripped the restated H1 prefix from `guide/router/{vue2,vue3,react}` (`"Vue 3 Integration — @esmx/router"` → `"@esmx/router"`) and gave both `llms.md` pages a real suffix (`titleSuffix` was the H1 verbatim). e.g. `/guide/router/vue3` now renders `Vue 3 Integration - @esmx/router`.

The remaining ~50 pages the audit flagged are mild single-word overlaps (e.g. "Router - Router Class API Reference") that read fine; leaving those as optional Option-A polish.

Verified: docs build passes; the 5 titles render de-duplicated; fences render correctly. Version-badge (hub/core) verified via CI + preview.