### PR TITLE
docs(api): document @esmx/core middleware API + fix heading hierarchy

### DIFF
--- a/examples/docs/src/en/api/core/_meta.json
+++ b/examples/docs/src/en/api/core/_meta.json
@@ -1,5 +1,6 @@
 [
     "esmx",
+    "middleware",
     "app",
     "render-context",
     "module-config",

--- a/examples/docs/src/en/api/core/esmx.md
+++ b/examples/docs/src/en/api/core/esmx.md
@@ -108,14 +108,14 @@ interface EsmxOptions {
 }
 ```
 
-#### root
+### root
 
 - **Type**: `string`
 - **Default**: `process.cwd()`
 
 Project root directory path. Can be an absolute or relative path; relative paths are resolved based on the current working directory.
 
-#### isProd
+### isProd
 
 - **Type**: `boolean`
 - **Default**: `process.env.NODE_ENV === 'production'`
@@ -124,26 +124,26 @@ Environment identifier.
 - `true`: Production environment
 - `false`: Development environment
 
-#### basePathPlaceholder
+### basePathPlaceholder
 
 - **Type**: `string | false`
 - **Default**: `'[[[___ESMX_DYNAMIC_BASE___]]]'`
 
 Base path placeholder configuration. Used for runtime dynamic replacement of resource base paths. Set to `false` to disable this feature.
 
-#### modules
+### modules
 
 - **Type**: `ModuleConfig`
 
 Module configuration options. Used to configure project module resolution rules, including module aliases, external dependencies, etc.
 
-#### packs
+### packs
 
 - **Type**: `PackConfig`
 
 Packaging configuration options. Used to package build artifacts into standard npm .tgz format packages.
 
-#### devApp
+### devApp
 
 - **Type**: `(esmx: Esmx) => Promise<App>`
 
@@ -161,7 +161,7 @@ export default {
 }
 ```
 
-#### server
+### server
 
 - **Type**: `(esmx: Esmx) => Promise<void>`
 
@@ -184,7 +184,7 @@ export default {
 }
 ```
 
-#### postBuild
+### postBuild
 
 - **Type**: `(esmx: Esmx) => Promise<void>`
 

--- a/examples/docs/src/en/api/core/middleware.md
+++ b/examples/docs/src/en/api/core/middleware.md
@@ -72,7 +72,7 @@ const app = mergeMiddlewares([loggerMiddleware, createMiddleware(esmx)]);
 function isImmutableFile(filename: string): boolean;
 ```
 
-Returns `true` when a file path matches Esmx's content-hashed (immutable) asset pattern — i.e. safe to serve with `Cache-Control: immutable, max-age=31536000`. `createMiddleware` uses it internally to decide the cache policy for each asset.
+Returns `true` when a file path matches Esmx's content-hashed (immutable) asset pattern — i.e. safe to serve with `Cache-Control: public, max-age=31536000, immutable`. `createMiddleware` uses it internally to decide the cache policy for each asset.
 
 ## Related
 

--- a/examples/docs/src/en/api/core/middleware.md
+++ b/examples/docs/src/en/api/core/middleware.md
@@ -1,0 +1,80 @@
+---
+titleSuffix: "@esmx/core HTTP Middleware API"
+description: "Reference for @esmx/core middleware: the Middleware type, createMiddleware, mergeMiddlewares, and isImmutableFile for serving module static assets with correct caching."
+head:
+  - - "meta"
+    - name: "keywords"
+      content: "Esmx, middleware, createMiddleware, mergeMiddlewares, isImmutableFile, static assets, cache control, SSR server"
+---
+
+# Middleware
+
+`@esmx/core` exposes a small set of connect-style middleware helpers used to serve a module's static assets (the built `dist/client` output) with correct cache headers. These are what `esmx.middleware` is built from, and you can compose them directly when wiring your own HTTP server.
+
+## `Middleware`
+
+```ts
+type Middleware = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: Function
+) => void;
+```
+
+A connect-style middleware: it receives the Node request and response plus a `next` callback, and either handles the request or calls `next()` to pass control on. It is compatible with `http`, Express, Koa (via adapters), and most Node servers.
+
+```ts
+const loggerMiddleware: Middleware = (req, res, next) => {
+    console.log(`${req.method} ${req.url}`);
+    next();
+};
+```
+
+## `createMiddleware(esmx)`
+
+```ts
+function createMiddleware(esmx: Esmx): Middleware;
+```
+
+Creates the middleware that serves static resources for every module in the Esmx instance. It:
+
+- builds a static-file handler per module from the module configuration,
+- applies cache control per request, and
+- serves content-hashed (immutable) files with long-lived caching.
+
+```ts
+import { Esmx, createMiddleware } from '@esmx/core';
+
+const esmx = new Esmx();
+const middleware = createMiddleware(esmx);
+
+// Use it in any Node HTTP server
+server.use(middleware);
+```
+
+## `mergeMiddlewares(middlewares)`
+
+```ts
+function mergeMiddlewares(middlewares: Middleware[]): Middleware;
+```
+
+Composes an array of middlewares into a single middleware, running them in order until one handles the request or the chain ends (calling the outer `next`). Useful for combining `createMiddleware`'s output with your own handlers.
+
+```ts
+import { mergeMiddlewares } from '@esmx/core';
+
+const app = mergeMiddlewares([loggerMiddleware, createMiddleware(esmx)]);
+```
+
+## `isImmutableFile(filename)`
+
+```ts
+function isImmutableFile(filename: string): boolean;
+```
+
+Returns `true` when a file path matches Esmx's content-hashed (immutable) asset pattern — i.e. safe to serve with `Cache-Control: immutable, max-age=31536000`. `createMiddleware` uses it internally to decide the cache policy for each asset.
+
+## Related
+
+- [Esmx](/api/core/esmx) — the core class whose `middleware` is composed from these helpers
+- [RenderContext](/api/core/render-context) — how rendered HTML references the assets these serve

--- a/examples/docs/src/en/api/core/render-context.md
+++ b/examples/docs/src/en/api/core/render-context.md
@@ -111,7 +111,7 @@ interface RenderContextOptions {
 }
 ```
 
-#### base
+### base
 
 - **Type**: `string`
 - **Default**: `''`
@@ -121,7 +121,7 @@ Base path for static resources.
 - Supports runtime dynamic configuration without rebuilding
 - Commonly used in multi-language sites, micro-frontend applications, and other scenarios
 
-#### entryName
+### entryName
 
 - **Type**: `string`
 - **Default**: `'default'`
@@ -136,7 +136,7 @@ export const desktop = async (rc: RenderContext) => {
 };
 ```
 
-#### params
+### params
 
 - **Type**: `Record<string, any>`
 - **Default**: `{}`
@@ -153,7 +153,7 @@ const rc = await esmx.render({
 });
 ```
 
-#### importmapMode
+### importmapMode
 
 - **Type**: `'inline' | 'js'`
 - **Default**: `'inline'`

--- a/examples/docs/src/zh/api/core/_meta.json
+++ b/examples/docs/src/zh/api/core/_meta.json
@@ -1,5 +1,6 @@
 [
     "esmx",
+    "middleware",
     "app",
     "render-context",
     "module-config",

--- a/examples/docs/src/zh/api/core/esmx.md
+++ b/examples/docs/src/zh/api/core/esmx.md
@@ -108,14 +108,14 @@ interface EsmxOptions {
 }
 ```
 
-#### root
+### root
 
 - **类型**: `string`
 - **默认值**: `process.cwd()`
 
 项目根目录路径。可以是绝对路径或相对路径，相对路径基于当前工作目录解析。
 
-#### isProd
+### isProd
 
 - **类型**: `boolean`
 - **默认值**: `process.env.NODE_ENV === 'production'`
@@ -124,26 +124,26 @@ interface EsmxOptions {
 - `true`: 生产环境
 - `false`: 开发环境
 
-#### basePathPlaceholder
+### basePathPlaceholder
 
 - **类型**: `string | false`
 - **默认值**: `'[[[___ESMX_DYNAMIC_BASE___]]]'`
 
 基础路径占位符配置。用于运行时动态替换资源的基础路径。设置为 `false` 可以禁用此功能。
 
-#### modules
+### modules
 
 - **类型**: `ModuleConfig`
 
 模块配置选项。用于配置项目的模块解析规则，包括模块别名、外部依赖等配置。
 
-#### packs
+### packs
 
 - **类型**: `PackConfig`
 
 打包配置选项。用于将构建产物打包成标准的 npm .tgz 格式软件包。
 
-#### devApp
+### devApp
 
 - **类型**: `(esmx: Esmx) => Promise<App>`
 
@@ -161,7 +161,7 @@ export default {
 }
 ```
 
-#### server
+### server
 
 - **类型**: `(esmx: Esmx) => Promise<void>`
 
@@ -184,7 +184,7 @@ export default {
 }
 ```
 
-#### postBuild
+### postBuild
 
 - **类型**: `(esmx: Esmx) => Promise<void>`
 

--- a/examples/docs/src/zh/api/core/middleware.md
+++ b/examples/docs/src/zh/api/core/middleware.md
@@ -1,0 +1,80 @@
+---
+titleSuffix: "@esmx/core HTTP 中间件 API"
+description: "@esmx/core 中间件参考:Middleware 类型、createMiddleware、mergeMiddlewares 与 isImmutableFile——以正确的缓存策略服务模块静态资源。"
+head:
+  - - "meta"
+    - name: "keywords"
+      content: "Esmx, 中间件, createMiddleware, mergeMiddlewares, isImmutableFile, 静态资源, 缓存控制, SSR 服务端"
+---
+
+# 中间件
+
+`@esmx/core` 提供一组 connect 风格的中间件辅助函数,用于以正确的缓存头服务模块的静态资源(即构建产物 `dist/client`)。`esmx.middleware` 正是由它们组合而成,你也可以在自建 HTTP 服务器时直接组合使用。
+
+## `Middleware`
+
+```ts
+type Middleware = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: Function
+) => void;
+```
+
+connect 风格中间件:接收 Node 的请求、响应对象和 `next` 回调,要么处理该请求,要么调用 `next()` 交由后续处理。兼容 `http`、Express、Koa(经适配)及大多数 Node 服务器。
+
+```ts
+const loggerMiddleware: Middleware = (req, res, next) => {
+    console.log(`${req.method} ${req.url}`);
+    next();
+};
+```
+
+## `createMiddleware(esmx)`
+
+```ts
+function createMiddleware(esmx: Esmx): Middleware;
+```
+
+创建为 Esmx 实例中每个模块服务静态资源的中间件。它会:
+
+- 依据模块配置为每个模块构建静态文件处理器,
+- 逐请求应用缓存控制,
+- 对内容指纹(不可变)文件采用长期缓存。
+
+```ts
+import { Esmx, createMiddleware } from '@esmx/core';
+
+const esmx = new Esmx();
+const middleware = createMiddleware(esmx);
+
+// 在任意 Node HTTP 服务器中使用
+server.use(middleware);
+```
+
+## `mergeMiddlewares(middlewares)`
+
+```ts
+function mergeMiddlewares(middlewares: Middleware[]): Middleware;
+```
+
+将中间件数组组合为单个中间件,按顺序执行,直到某个处理该请求或链结束(调用外层 `next`)。适合把 `createMiddleware` 的产物与你自己的处理器组合起来。
+
+```ts
+import { mergeMiddlewares } from '@esmx/core';
+
+const app = mergeMiddlewares([loggerMiddleware, createMiddleware(esmx)]);
+```
+
+## `isImmutableFile(filename)`
+
+```ts
+function isImmutableFile(filename: string): boolean;
+```
+
+当文件路径匹配 Esmx 的内容指纹(不可变)资源模式时返回 `true`——即可安全地以 `Cache-Control: immutable, max-age=31536000` 服务。`createMiddleware` 内部用它为每个资源决定缓存策略。
+
+## 相关
+
+- [Esmx](/zh/api/core/esmx) —— 其 `middleware` 由这些辅助函数组合而成的核心类
+- [RenderContext](/zh/api/core/render-context) —— 渲染后的 HTML 如何引用这些资源

--- a/examples/docs/src/zh/api/core/middleware.md
+++ b/examples/docs/src/zh/api/core/middleware.md
@@ -72,7 +72,7 @@ const app = mergeMiddlewares([loggerMiddleware, createMiddleware(esmx)]);
 function isImmutableFile(filename: string): boolean;
 ```
 
-当文件路径匹配 Esmx 的内容指纹(不可变)资源模式时返回 `true`——即可安全地以 `Cache-Control: immutable, max-age=31536000` 服务。`createMiddleware` 内部用它为每个资源决定缓存策略。
+当文件路径匹配 Esmx 的内容指纹(不可变)资源模式时返回 `true`——即可安全地以 `Cache-Control: public, max-age=31536000, immutable` 服务。`createMiddleware` 内部用它为每个资源决定缓存策略。
 
 ## 相关
 

--- a/examples/docs/src/zh/api/core/render-context.md
+++ b/examples/docs/src/zh/api/core/render-context.md
@@ -110,7 +110,7 @@ interface RenderContextOptions {
 }
 ```
 
-#### base
+### base
 
 - **类型**: `string`
 - **默认值**: `''`
@@ -120,7 +120,7 @@ interface RenderContextOptions {
 - 支持运行时动态配置，无需重新构建
 - 常用于多语言站点、微前端应用等场景
 
-#### entryName
+### entryName
 
 - **类型**: `string`
 - **默认值**: `'default'`
@@ -135,7 +135,7 @@ export const desktop = async (rc: RenderContext) => {
 };
 ```
 
-#### params
+### params
 
 - **类型**: `Record<string, any>`
 - **默认值**: `{}`
@@ -152,7 +152,7 @@ const rc = await esmx.render({
 });
 ```
 
-#### importmapMode
+### importmapMode
 
 - **类型**: `'inline' | 'js'`
 - **默认值**: `'inline'`


### PR DESCRIPTION
Final docs polish from the on-site audit.

- **New `api/core/middleware` page (en+zh)**: documents the public middleware surface that was exported from `@esmx/core` but undocumented — the `Middleware` type, `createMiddleware`, `mergeMiddlewares`, `isImmutableFile` — with signatures and examples. Registered in `api/core/_meta.json`.
- **Heading hierarchy**: `esmx.md` and `render-context.md` (en+zh) had `Instance Options` members as h4 directly under an h2 (skipping h3, an a11y/outline issue). Demoted to h3 to match `Instance Properties`; h4s correctly nested under an h3 (ImportMap's SpecifierMap/ScopesMap) are untouched.

**Deferred (needs maintainer decision, not guessed):** the `declaration`/diagnostics exports (`readDeclaration`, `resolveDeclaration`, `DiagnosticCode`) are public but undocumented — whether to document them or mark `@internal` is a product-ownership call. **Skipped:** demoting demo mount points from the sitemap — they carry real long-tail ranking value (e.g. /vue3/ ranks p1 for 'Vue 3 Micro-App'), so removing them would hurt, contrary to the audit's low-priority suggestion.

Verified: docs build, middleware page renders (en+zh, non-tautological title), ImportMap h4 preserved. Adversarial review + CI running.