### PR TITLE
fix(landing,i18n): translate hardcoded section labels + matrix copy for zh parity

### DIFF
--- a/examples/micro-app/ssr-micro-hub/src/landing-app.ts
+++ b/examples/micro-app/ssr-micro-hub/src/landing-app.ts
@@ -163,7 +163,7 @@ export class LandingApp extends BaseApp {
             `<section class="section painpoints" id="features">` +
             `<div class="container">` +
             `<div class="section-header reveal">` +
-            `<span class="section-label">WHY ESMX</span>` +
+            `<span class="section-label">${t(this.router, 'labelWhy')}</span>` +
             `<h2 class="section-title">${t(this.router, 'whyTitle')}</h2>` +
             `<p class="section-desc">${t(this.router, 'whyDesc')}</p>` +
             `</div>` +
@@ -218,7 +218,7 @@ export class LandingApp extends BaseApp {
             `<section class="section">` +
             `<div class="container">` +
             `<div class="section-header reveal">` +
-            `<span class="section-label">FEATURES</span>` +
+            `<span class="section-label">${t(this.router, 'labelFeatures')}</span>` +
             `<h2 class="section-title">${t(this.router, 'featuresTitle')}</h2>` +
             `<p class="section-desc">${t(this.router, 'featuresDesc')}</p>` +
             `</div>` +
@@ -270,7 +270,7 @@ export class LandingApp extends BaseApp {
             `<section class="section code-demo" id="quickstart">` +
             `<div class="container">` +
             `<div class="section-header reveal">` +
-            `<span class="section-label">QUICK START</span>` +
+            `<span class="section-label">${t(this.router, 'labelQuickstart')}</span>` +
             `<h2 class="section-title">${t(this.router, 'quickstartTitle')}</h2>` +
             `<p class="section-desc">${t(this.router, 'quickstartDesc')}</p>` +
             `</div>` +
@@ -330,7 +330,7 @@ export class LandingApp extends BaseApp {
             `<section class="section" id="ecosystem">` +
             `<div class="container">` +
             `<div class="section-header reveal">` +
-            `<span class="section-label">ECOSYSTEM</span>` +
+            `<span class="section-label">${t(this.router, 'labelEco')}</span>` +
             `<h2 class="section-title">${t(this.router, 'ecoTitle')}</h2>` +
             `<p class="section-desc">${t(this.router, 'ecoDesc')}</p>` +
             `</div>` +
@@ -430,9 +430,9 @@ export class LandingApp extends BaseApp {
             `<section class="section matrix-section" id="matrix">` +
             `<div class="container">` +
             `<div class="section-header reveal">` +
-            `<span class="section-label">21 LIVE DEMOS</span>` +
-            `<h2 class="section-title">Framework × Bundler</h2>` +
-            `<p class="section-desc">Every cell is a live micro-app linked via native ESM. Click to open it.</p>` +
+            `<span class="section-label">${t(this.router, 'labelDemos')}</span>` +
+            `<h2 class="section-title">${t(this.router, 'matrixTitle')}</h2>` +
+            `<p class="section-desc">${t(this.router, 'matrixDesc')}</p>` +
             `</div>` +
             `<div class="matrix-wrap reveal">` +
             `<table class="matrix">` +
@@ -458,7 +458,7 @@ export class LandingApp extends BaseApp {
             `<section class="section" style="text-align: center;">
                 <div class="container">
                     <div class="section-header reveal">
-                        <span class="section-label">LIVE DEMO</span>
+                        <span class="section-label">${t(this.router, 'labelLiveDemo')}</span>
                         <h2 class="section-title">${t(this.router, 'liveTitle')}</h2>
                         <p class="section-desc">${t(this.router, 'liveDesc')}</p>
                     </div>

--- a/examples/micro-app/ssr-micro-shared/src/i18n.ts
+++ b/examples/micro-app/ssr-micro-shared/src/i18n.ts
@@ -40,6 +40,15 @@ const messages = {
         heroBtnQuickstart: 'Quick Start',
         heroBtnDemo: 'Explore Live Demo',
         whyTitle: 'Built for the agent era',
+        labelWhy: 'WHY ESMX',
+        labelFeatures: 'FEATURES',
+        labelQuickstart: 'QUICK START',
+        labelEco: 'ECOSYSTEM',
+        labelDemos: '21 LIVE DEMOS',
+        labelLiveDemo: 'LIVE DEMO',
+        matrixTitle: 'Framework × Bundler',
+        matrixDesc:
+            'Every cell is a live micro-app linked via native ESM. Click to open it.',
         whyDesc:
             'Other micro-frontend frameworks invented their own lifecycle hooks, loader DSLs, and globals. Esmx is plain ESM + import maps — the same surface LLMs were trained on. Less to learn, less to hallucinate.',
         painLabelBad: 'Traditional',
@@ -144,6 +153,15 @@ const messages = {
         heroBtnQuickstart: '快速开始',
         heroBtnDemo: '探索在线 Demo',
         whyTitle: '为 agent 时代而生',
+        labelWhy: '为什么选 Esmx',
+        labelFeatures: '特性',
+        labelQuickstart: '快速开始',
+        labelEco: '生态',
+        labelDemos: '21 个在线 Demo',
+        labelLiveDemo: '在线 Demo',
+        matrixTitle: '框架 × 构建器',
+        matrixDesc:
+            '每个格子都是一个由原生 ESM 链接的在线微应用,点击即可打开。',
         whyDesc:
             '其他微前端框架发明了自己的生命周期钩子、loader DSL 和全局对象。Esmx 只是原生 ESM + import map —— 跟 LLM 训练数据同一表面。学得少,幻觉少。',
         painLabelBad: '传统方案',

--- a/examples/micro-app/ssr-micro-shared/src/i18n.ts
+++ b/examples/micro-app/ssr-micro-shared/src/i18n.ts
@@ -161,7 +161,7 @@ const messages = {
         labelLiveDemo: '在线 Demo',
         matrixTitle: '框架 × 构建器',
         matrixDesc:
-            '每个格子都是一个由原生 ESM 链接的在线微应用,点击即可打开。',
+            '每个格子都是一个由原生 ESM 链接的在线微应用，点击即可打开。',
         whyDesc:
             '其他微前端框架发明了自己的生命周期钩子、loader DSL 和全局对象。Esmx 只是原生 ESM + import map —— 跟 LLM 训练数据同一表面。学得少,幻觉少。',
         painLabelBad: '传统方案',


### PR DESCRIPTION
Final on-site item — landing-page content-parity.

The section eyebrow labels (**WHY ESMX / FEATURES / QUICK START / ECOSYSTEM / 21 LIVE DEMOS / LIVE DEMO**) and the **Framework × Bundler** matrix title + subtitle were hardcoded English, so Chinese visitors saw English strings there while the rest of the page was translated. Moved them to i18n keys with Chinese translations (e.g. 特性 / 生态 / 框架 × 构建器).

- Bundler column headers (Vite 8 / Rspack / Rsbuild) left as product names.
- **EN output is unchanged** (same strings via i18n), so the hub-landing visual baseline is unaffected.

Verified: template interpolation context correct, lint clean. Adversarial review + CI running. This closes the on-site audit backlog.