### PR TITLE
fix(hub): prerender all 15 demos, fix links and titles

### DIFF
--- a/examples/micro-app/ssr-micro-hub/src/entry.node.ts
+++ b/examples/micro-app/ssr-micro-hub/src/entry.node.ts
@@ -75,14 +75,25 @@ export default {
         // docs. Locale is derived from the URL in entry.server, and the client
         // can switch via SPA navigation (history pushState, no full reload).
         const base = 'http://localhost:3000/';
+        // Every demo route registered in routes.ts must be prerendered here:
+        // the SPA router knows them all, but only paths in this list get a
+        // static HTML entry point at the site root. A missing entry 404s on
+        // direct navigation / crawl even though in-app SPA navigation works —
+        // so this list must stay in sync with routes.ts (all 15 demos live).
         const routes = [
             '',
             'demo/',
             'html/',
+            'rsbuild-html/',
+            'vite-html/',
             'lit/',
             'vue2/',
             'vue3/',
+            'rsbuild-vue/',
+            'vite-vue/',
             'react/',
+            'rsbuild-react/',
+            'vite-react/',
             'preact/',
             'preact-htm/',
             'solid/',

--- a/examples/micro-app/ssr-micro-hub/src/home-app.ts
+++ b/examples/micro-app/ssr-micro-hub/src/home-app.ts
@@ -175,7 +175,7 @@ export class HomeApp extends BaseApp {
             <aside class="hub-callout">
                 <p class="hub-callout__lead">Using Esmx with an AI assistant?</p>
                 <p class="hub-callout__body">
-                    Feed it <a href="/guide/essentials/styles" target="_blank">esmx.dev/llms.md</a> —
+                    Feed it <a href="/llms.md" target="_blank">esmx.dev/llms.md</a> —
                     one file, every code block CI-validated, versioned with Esmx.
                 </p>
             </aside>

--- a/examples/micro-app/ssr-micro-rsbuild-html/src/html-app.ts
+++ b/examples/micro-app/ssr-micro-rsbuild-html/src/html-app.ts
@@ -31,7 +31,7 @@ export class HtmlApp extends BaseApp {
     protected getHead() {
         return buildSeoHead(this.router, {
             path: '/rsbuild-html/',
-            title: t(this.router, 'fwHtmlTitle'),
+            title: `${t(this.router, 'fwHtmlTitle')} · Rsbuild`,
             description: t(this.router, 'fwHtmlDesc')
         });
     }

--- a/examples/micro-app/ssr-micro-rsbuild-react/src/app.tsx
+++ b/examples/micro-app/ssr-micro-rsbuild-react/src/app.tsx
@@ -55,7 +55,7 @@ export function AppContent() {
     useHead(
         buildSeoHead(router, {
             path: '/rsbuild-react/',
-            title: t(router, 'fwReactTitle'),
+            title: `${t(router, 'fwReactTitle')} · Rsbuild`,
             description: t(router, 'fwReactDesc')
         })
     );

--- a/examples/micro-app/ssr-micro-rsbuild-vue3/src/app.vue
+++ b/examples/micro-app/ssr-micro-rsbuild-vue3/src/app.vue
@@ -89,7 +89,7 @@ ${'</scr' + 'ipt>'}
 useHead(
     buildSeoHead(router, {
         path: '/rsbuild-vue/',
-        title,
+        title: `${title} · Rsbuild`,
         description: t(router, 'fwVue3Desc')
     })
 );

--- a/examples/micro-app/ssr-micro-vite-html/src/html-app.ts
+++ b/examples/micro-app/ssr-micro-vite-html/src/html-app.ts
@@ -31,7 +31,7 @@ export class HtmlApp extends BaseApp {
     protected getHead() {
         return buildSeoHead(this.router, {
             path: '/vite-html/',
-            title: t(this.router, 'fwHtmlTitle'),
+            title: `${t(this.router, 'fwHtmlTitle')} · Vite`,
             description: t(this.router, 'fwHtmlDesc')
         });
     }

--- a/examples/micro-app/ssr-micro-vite-react/src/app.tsx
+++ b/examples/micro-app/ssr-micro-vite-react/src/app.tsx
@@ -55,7 +55,7 @@ export function AppContent() {
     useHead(
         buildSeoHead(router, {
             path: '/vite-react/',
-            title: t(router, 'fwReactTitle'),
+            title: `${t(router, 'fwReactTitle')} · Vite`,
             description: t(router, 'fwReactDesc')
         })
     );

--- a/examples/micro-app/ssr-micro-vite-vue3/src/app.vue
+++ b/examples/micro-app/ssr-micro-vite-vue3/src/app.vue
@@ -90,8 +90,8 @@ ${'</scr' + 'ipt>'}
 
 useHead(
     buildSeoHead(router, {
-        path: '/vue3/',
-        title,
+        path: '/vite-vue/',
+        title: `${title} · Vite`,
         description: t(router, 'fwVue3Desc')
     })
 );


### PR DESCRIPTION
## Problem

The demo hub (`/demo/`) lists **15 demos, all labelled "live"** — but 6 of them 404 on direct navigation / crawl:

- `/rsbuild-html/` `/vite-html/` `/rsbuild-vue/` `/vite-vue/` `/rsbuild-react/` `/vite-react/` → **404**

Root cause: the `postBuild` prerender list in `entry.node.ts` emitted static HTML for only 9 demos. The 6 rsbuild/vite variants are registered in the SPA router (so in-app SPA nav works) but had no static entry point — the deployed static site 404s them.

## Fixes

1. **404 links** — add the 6 missing demos to the prerender list (en + zh). All 15 advertised demos now resolve; sitemap (auto-derived from emitted HTML) picks them up automatically.
2. **Wrong link** — the AI-assistant callout in `home-app.ts` linked to `/guide/essentials/styles` while its text reads `esmx.dev/llms.md` → now `href="/llms.md"`.
3. **Wrong canonical** — `ssr-micro-vite-vue3` used `path: '/vue3/'` in `buildSeoHead`, so `/vite-vue/`'s canonical/og:url pointed at a *different* demo → fixed to `/vite-vue/`.
4. **Duplicate titles** — the 3 bundler variants of each framework shared one `<title>`. Making them live would create duplicate titles → variants now suffixed `· Rsbuild` / `· Vite`; base demos keep the flagship keyword. Visible H1 unchanged.

## Verification

- Rebuilt hub + 6 variant apps: all 15 demo HTML entries emit (en + zh), ~41 KB each, real content.
- All 32 pages self-canonical (0 mismatches); 16 en + 16 zh `<title>` values all unique.
- `lint:type` clean on affected packages.
- Visible content unchanged → committed playwright visual baselines still match (no baseline regen needed).
- Adversarial acceptance review (4 lenses running builds/greps/curls) surfaced 0 blocker/major findings.