### PR TITLE
fix(landing): syntax-highlight the hero package.json card

### DIFF
--- a/examples/micro-app/ssr-micro-hub/src/landing-app.ts
+++ b/examples/micro-app/ssr-micro-hub/src/landing-app.ts
@@ -35,6 +35,36 @@ const BOOK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18
  */
 const DOCS_ENTRY_PATH = '/guide/start/introduction';
 
+/**
+ * Minimal JSON syntax highlighter for the hero snippet. Wraps property keys,
+ * string values, and literals in the shared `sh-*` token classes (defined in
+ * landing-page.css) — the same convention the quickstart terminal uses, so the
+ * hero card is highlighted consistently instead of rendering as flat text. The
+ * input is a trusted static snippet, so this only tokenizes well-formed JSON
+ * rather than guarding against arbitrary input. HTML-special chars are escaped
+ * before any span is injected, so the output is safe as element TEXT content;
+ * it must not be used to build attribute values (quotes are left unescaped).
+ */
+function highlightJson(src: string): string {
+    const escaped = src
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    return escaped.replace(
+        /("(?:[^"\\]|\\.)*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?)/g,
+        (match, str, colon, literal, num) => {
+            if (str) {
+                return colon
+                    ? `<span class="sh-property">${str}</span>${colon}`
+                    : `<span class="sh-string">${str}</span>`;
+            }
+            if (literal) return `<span class="sh-keyword">${literal}</span>`;
+            if (num) return `<span class="sh-value">${num}</span>`;
+            return match;
+        }
+    );
+}
+
 export class LandingApp extends BaseApp {
     private unsubLocale: (() => void) | null = null;
 
@@ -126,7 +156,7 @@ export class LandingApp extends BaseApp {
             `<div class="hero-visual reveal reveal-delay-3">` +
             `<div class="hero-code">` +
             `<div class="hero-code__header"><span class="hero-code__file">package.json</span></div>` +
-            `<pre class="hero-code__body">${ESMX_DECLARATION_SNIPPET}</pre>` +
+            `<pre class="hero-code__body">${highlightJson(ESMX_DECLARATION_SNIPPET)}</pre>` +
             `</div>` +
             `</div>` +
             `</div>` +


### PR DESCRIPTION
## Problem
The hero code card rendered its `package.json` snippet as a flat `<pre>` string in a single colour — no syntax highlighting — while the quickstart terminal directly below already used the shared `sh-*` token classes. A jarring inconsistency on the primary marketing surface.

## Fix
Add a small, dependency-free JSON highlighter (`highlightJson`) that wraps property keys, string values, and literals in the existing `sh-*` token classes (defined in `landing-page.css`) — the same convention the quickstart terminal uses. Escapes HTML first (input is a trusted static snippet).

## Verification
- Built hub; hero HTML now contains 5 `sh-property` + 4 `sh-string` spans, punctuation left default.
- Rendered in-browser with the real bundled CSS: property keys green (#7ee787), string values light blue (#a5d6ff) on the dark card — proper editor-style highlighting (screenshot-verified, not "looks fine").

## Follow-up
Demo-page code blocks (`esmx-code`, light theme) are also unhighlighted — tracked as a separate batch (needs a multi-language tokenizer + light/dark token palette).