### PR TITLE
fix(docs,core,router,rspack): correct API signatures and 4 runtime bugs

### DIFF
--- a/examples/docs/src/en/api/app/rspack-vue.mdx
+++ b/examples/docs/src/en/api/app/rspack-vue.mdx
@@ -32,7 +32,7 @@ interface RspackVueAppOptions extends RspackHtmlAppOptions {
 Vue application configuration options interface, inherits from `@esmx/rspack`'s `RspackHtmlAppOptions`:
 - `vueLoader`: vue-loader configuration options
 
-For details on base types, please refer to the [@esmx/rspack documentation](./rspack.md).
+For details on base types, please refer to the [@esmx/rspack documentation](./rspack#rspackhtmlappoptions).
 
 ## Function Exports
 

--- a/examples/docs/src/en/api/core/esmx.md
+++ b/examples/docs/src/en/api/core/esmx.md
@@ -251,7 +251,7 @@ Gets the static resource handling middleware. Provides different implementations
 ```ts
 const server = http.createServer((req, res) => {
   esmx.middleware(req, res, async () => {
-    const rc = await esmx.render({ url: req.url });
+    const rc = await esmx.render({ params: { url: req.url } });
     res.end(rc.html);
   });
 });
@@ -549,7 +549,7 @@ async server(esmx) {
 Get build manifest list.
 
 - **Parameters**:
-  - `target`: `BuildEnvironment` - Target environment type
+  - `env`: `BuildEnvironment` - Target environment type
     - `'client'`: Client environment
     - `'server'`: Server environment
 
@@ -587,7 +587,7 @@ async server(esmx) {
 Get import mapping object.
 
 - **Parameters**:
-  - `target`: `BuildEnvironment` - Target environment type
+  - `env`: `BuildEnvironment` - Target environment type
     - `'client'`: Generate import map for browser environment
     - `'server'`: Generate import map for server environment
 
@@ -644,6 +644,7 @@ Get client import map information.
       src: string;
       filepath: string;
       code: string;
+      integrity: Record<string, string> | null;
     }
     ```
   - Inline mode:
@@ -652,6 +653,7 @@ Get client import map information.
       src: null;
       filepath: null;
       code: string;
+      integrity: Record<string, string> | null;
     }
     ```
 
@@ -703,7 +705,7 @@ async server(esmx) {
 Gets the module's static import path list.
 
 - **Parameters**:
-  - `target`: `BuildEnvironment` - Build target
+  - `env`: `BuildEnvironment` - Build target
     - `'client'`: Client environment
     - `'server'`: Server environment
   - `specifier`: `string` - Module specifier

--- a/examples/docs/src/en/api/core/manifest-json.md
+++ b/examples/docs/src/en/api/core/manifest-json.md
@@ -17,7 +17,11 @@ head:
 
 ```typescript
 interface ManifestJson {
+  protocol: number;
   name: string;
+  version: string;
+  provides: Record<string, ManifestJsonProvide>;
+  uses: string[];
   scopes: Record<string, Record<string, string>>;
   exports: ManifestJsonExports;
   files: string[];
@@ -26,10 +30,30 @@ interface ManifestJson {
 }
 ```
 
+#### protocol
+
+- **Type**: `number`
+- **Description**: Manifest protocol version (RFC 0001 §5), currently `2`. Absent in pre-v2 manifests; readers treat absence as protocol 1 and skip v2-only checks. The linker rejects manifests whose `protocol` is higher than the supported version.
+
 #### name
 
 - **Type**: `string`
 - **Description**: Module name, sourced from the module configuration
+
+#### version
+
+- **Type**: `string`
+- **Description**: Module version, transcribed from the module's `package.json` at build time (RFC 0001 §5). Pre-v2 manifests default to `'0.0.0'` at read time.
+
+#### provides
+
+- **Type**: `Record<string, ManifestJsonProvide>`
+- **Description**: Resolved versions for every pkg-export (`pkg: true`) package, captured at build time (RFC 0001 §5). Keys are package specifiers; values record the resolved installed version.
+
+#### uses
+
+- **Type**: `string[]`
+- **Description**: Consumption edges transcribed from the module's `package.json` `esmx.uses` declaration (RFC 0001 §5). Pre-v2 manifests default to `[]` at read time.
 
 #### scopes
 
@@ -63,6 +87,21 @@ type ManifestJsonExports = Record<string, ManifestJsonExport>;
 ```
 
 An export item configuration mapping, where the key is the export path and the value is the export item information.
+
+### ManifestJsonProvide
+
+```typescript
+interface ManifestJsonProvide {
+  version: string;
+}
+```
+
+Build-time facts about one provided (pkg-export) package (RFC 0001 §5).
+
+#### version
+
+- **Type**: `string`
+- **Description**: The resolved installed version of the provided package at build time, read from `node_modules/<pkg>/package.json` relative to the module root. Subpath specifiers (e.g. `vue/jsx-runtime`) resolve via their parent package. `'0.0.0'` when the package could not be resolved.
 
 ### ManifestJsonExport
 

--- a/examples/docs/src/en/api/router-react/hooks.md
+++ b/examples/docs/src/en/api/router-react/hooks.md
@@ -131,7 +131,7 @@ function CustomLink({ to, children }) {
     const link = useLink({ to, type: 'push', exact: 'include' });
 
     return (
-        <a href={link.href} onClick={link.navigate}>
+        <a {...link.attributes} onClick={link.navigate}>
             {children}
         </a>
     );

--- a/examples/docs/src/en/api/router-react/ssr.md
+++ b/examples/docs/src/en/api/router-react/ssr.md
@@ -41,7 +41,7 @@ export default async (rc: RenderContext) => {
     const html = await router.renderToString();
 
     // Collect route data for client hydration
-    const routeData = router.route.data;
+    const routeData = router.data;
 
     rc.html = `<!DOCTYPE html>
 <html lang="en">

--- a/examples/docs/src/en/api/router/router.md
+++ b/examples/docs/src/en/api/router/router.md
@@ -51,6 +51,10 @@ interface RouterOptions {
     zIndex?: number;
     handleBackBoundary?: (router: Router) => void;
     handleLayerClose?: (router: Router, data?: any) => void;
+    resolveLink?: (
+        link: RouterLinkResolved,
+        props: RouterLinkProps
+    ) => RouterLinkResolved;
 }
 ```
 

--- a/examples/docs/src/en/api/router/types.md
+++ b/examples/docs/src/en/api/router/types.md
@@ -438,6 +438,7 @@ Factory function that creates a micro-app instance from a router.
 ```ts
 interface RouterMicroAppOptions {
     mount: (el: HTMLElement) => void;
+    hydration?: (el: HTMLElement) => void;
     unmount: () => void;
     renderToString?: () => Awaitable<string>;
 }
@@ -445,6 +446,7 @@ interface RouterMicroAppOptions {
 
 Micro-app lifecycle interface:
 - `mount`: Mount the app into a DOM element
+- `hydration`: Optional hydration hook invoked on the client with the mount element
 - `unmount`: Unmount and clean up the app
 - `renderToString`: Optional SSR render method
 

--- a/examples/docs/src/en/guide/essentials/module-linking.md
+++ b/examples/docs/src/en/guide/essentials/module-linking.md
@@ -163,7 +163,7 @@ esmx validate          # human-readable report
 esmx validate --json   # machine-readable envelope (CI / agents)
 ```
 
-It exits non-zero only when an error-severity diagnostic is found; warnings alone exit 0. A package without an `esmx` field reports `protocol: "legacy"` and exits 0. The full diagnostic taxonomy (`E_NOT_LINKED`, `E_VERSION`, `E_SCHEMA`, `W_MULTI_CANDIDATE`, …) is documented in the [LLM briefing](/llms.md#diagnostics-the-complete-taxonomy).
+It exits non-zero only when an error-severity diagnostic is found; warnings alone exit 0. A package without an `esmx` field reports `protocol: "legacy"` and exits 0. The full diagnostic taxonomy (`E_NOT_LINKED`, `E_VERSION`, `E_SCHEMA`, `W_MULTI_MAJOR`, …) is documented in the [LLM briefing](/llms.md#diagnostics-the-complete-taxonomy).
 
 ## Complete example: multi-version coexistence
 

--- a/examples/docs/src/zh/api/app/rspack-vue.mdx
+++ b/examples/docs/src/zh/api/app/rspack-vue.mdx
@@ -32,7 +32,7 @@ interface RspackVueAppOptions extends RspackHtmlAppOptions {
 Vue 应用配置选项接口，继承自 `@esmx/rspack` 的 `RspackHtmlAppOptions`：
 - `vueLoader`: vue-loader 配置选项
 
-关于基础类型的详细说明，请参阅 [@esmx/rspack 文档](./rspack.md)。
+关于基础类型的详细说明，请参阅 [@esmx/rspack 文档](./rspack#rspackhtmlappoptions)。
 
 ## 函数导出
 

--- a/examples/docs/src/zh/api/core/esmx.md
+++ b/examples/docs/src/zh/api/core/esmx.md
@@ -251,7 +251,7 @@ export default {
 ```ts
 const server = http.createServer((req, res) => {
   esmx.middleware(req, res, async () => {
-    const rc = await esmx.render({ url: req.url });
+    const rc = await esmx.render({ params: { url: req.url } });
     res.end(rc.html);
   });
 });
@@ -549,7 +549,7 @@ async server(esmx) {
 获取构建清单列表。
 
 - **参数**:
-  - `target`: `BuildEnvironment` - 目标环境类型
+  - `env`: `BuildEnvironment` - 目标环境类型
     - `'client'`: 客户端环境
     - `'server'`: 服务端环境
 
@@ -587,7 +587,7 @@ async server(esmx) {
 获取导入映射对象。
 
 - **参数**:
-  - `target`: `BuildEnvironment` - 目标环境类型
+  - `env`: `BuildEnvironment` - 目标环境类型
     - `'client'`: 生成浏览器环境的导入映射
     - `'server'`: 生成服务端环境的导入映射
 
@@ -644,6 +644,7 @@ async server(esmx) {
       src: string;
       filepath: string;
       code: string;
+      integrity: Record<string, string> | null;
     }
     ```
   - 内联模式:
@@ -652,6 +653,7 @@ async server(esmx) {
       src: null;
       filepath: null;
       code: string;
+      integrity: Record<string, string> | null;
     }
     ```
 
@@ -703,7 +705,7 @@ async server(esmx) {
 获取模块的静态导入路径列表。
 
 - **参数**:
-  - `target`: `BuildEnvironment` - 构建目标
+  - `env`: `BuildEnvironment` - 构建目标
     - `'client'`: 客户端环境
     - `'server'`: 服务端环境
   - `specifier`: `string` - 模块标识符

--- a/examples/docs/src/zh/api/core/manifest-json.md
+++ b/examples/docs/src/zh/api/core/manifest-json.md
@@ -17,7 +17,11 @@ head:
 
 ```typescript
 interface ManifestJson {
+  protocol: number;
   name: string;
+  version: string;
+  provides: Record<string, ManifestJsonProvide>;
+  uses: string[];
   scopes: Record<string, Record<string, string>>;
   exports: ManifestJsonExports;
   files: string[];
@@ -26,10 +30,30 @@ interface ManifestJson {
 }
 ```
 
+#### protocol
+
+- **类型**: `number`
+- **描述**: 清单协议版本（RFC 0001 §5），当前为 `2`。v2 之前的清单没有该字段；读取端将缺失视为协议 1 并跳过 v2 专属检查。linker 会拒绝 `protocol` 高于支持版本的清单。
+
 #### name
 
 - **类型**: `string`
 - **描述**: 模块名称，来源于模块配置
+
+#### version
+
+- **类型**: `string`
+- **描述**: 模块版本，在构建时从模块的 `package.json` 转录（RFC 0001 §5）。v2 之前的清单在读取时默认为 `'0.0.0'`。
+
+#### provides
+
+- **类型**: `Record<string, ManifestJsonProvide>`
+- **描述**: 每个 pkg-export（`pkg: true`）包在构建时的已解析版本（RFC 0001 §5）。key 为包标识符，value 记录已解析的安装版本。
+
+#### uses
+
+- **类型**: `string[]`
+- **描述**: 从模块 `package.json` 的 `esmx.uses` 声明转录的消费边（RFC 0001 §5）。v2 之前的清单在读取时默认为 `[]`。
 
 #### scopes
 
@@ -63,6 +87,21 @@ type ManifestJsonExports = Record<string, ManifestJsonExport>;
 ```
 
 导出项配置映射，key为导出路径，value为导出项信息。
+
+### ManifestJsonProvide
+
+```typescript
+interface ManifestJsonProvide {
+  version: string;
+}
+```
+
+关于某个被提供（pkg-export）包的构建时事实（RFC 0001 §5）。
+
+#### version
+
+- **类型**: `string`
+- **描述**: 该被提供的包在构建时的已解析安装版本，从相对模块根目录的 `node_modules/<pkg>/package.json` 读取。子路径标识符（如 `vue/jsx-runtime`）通过其父包解析。当包无法解析时为 `'0.0.0'`。
 
 ### ManifestJsonExport
 

--- a/examples/docs/src/zh/api/router-react/hooks.md
+++ b/examples/docs/src/zh/api/router-react/hooks.md
@@ -131,7 +131,7 @@ function CustomLink({ to, children }) {
     const link = useLink({ to, type: 'push', exact: 'include' });
 
     return (
-        <a href={link.href} onClick={link.navigate}>
+        <a {...link.attributes} onClick={link.navigate}>
             {children}
         </a>
     );

--- a/examples/docs/src/zh/api/router-react/ssr.md
+++ b/examples/docs/src/zh/api/router-react/ssr.md
@@ -41,7 +41,7 @@ export default async (rc: RenderContext) => {
     const html = await router.renderToString();
 
     // 收集路由数据用于客户端水合
-    const routeData = router.route.data;
+    const routeData = router.data;
 
     rc.html = `<!DOCTYPE html>
 <html lang="zh">

--- a/examples/docs/src/zh/api/router/dynamic-matching.md
+++ b/examples/docs/src/zh/api/router/dynamic-matching.md
@@ -167,7 +167,7 @@ route.hash  // '#team'
 | `:id?` | 可选参数 | `/users` or `/users/42` |
 | `:path*` | 零个或多个段 | `/files` or `/files/a/b` |
 | `:path+` | 一个或多个段 | `/files/a` or `/files/a/b` |
-| `:id(\\\\d+)` | 带正则约束的参数 | `/users/42` (not `/users/alice`) |
+| `:id(\\d+)` | 带正则约束的参数 | `/users/42` (not `/users/alice`) |
 | `(.*)*` | 捕获所有通配符 | Anything |
 
 ### 自定义正则约束
@@ -177,7 +177,7 @@ route.hash  // '#team'
 ```ts
 const routes: RouteConfig[] = [
   // Only matches numeric IDs
-  { path: '/users/:id(\\\\d+)', component: UserProfile },
+  { path: '/users/:id(\\d+)', component: UserProfile },
 
   // Only matches specific values
   { path: '/:lang(en|fr|de)/docs', component: Docs }

--- a/examples/docs/src/zh/api/router/router.md
+++ b/examples/docs/src/zh/api/router/router.md
@@ -51,6 +51,10 @@ interface RouterOptions {
     zIndex?: number;
     handleBackBoundary?: (router: Router) => void;
     handleLayerClose?: (router: Router, data?: any) => void;
+    resolveLink?: (
+        link: RouterLinkResolved,
+        props: RouterLinkProps
+    ) => RouterLinkResolved;
 }
 ```
 

--- a/examples/docs/src/zh/api/router/types.md
+++ b/examples/docs/src/zh/api/router/types.md
@@ -438,6 +438,7 @@ type RouterMicroAppCallback = (router: Router) => RouterMicroAppOptions;
 ```ts
 interface RouterMicroAppOptions {
     mount: (el: HTMLElement) => void;
+    hydration?: (el: HTMLElement) => void;
     unmount: () => void;
     renderToString?: () => Awaitable<string>;
 }
@@ -445,6 +446,7 @@ interface RouterMicroAppOptions {
 
 微应用生命周期接口：
 - `mount`：将应用挂载到 DOM 元素
+- `hydration`：可选的水合钩子，在客户端执行时传入挂载元素
 - `unmount`：卸载并清理应用
 - `renderToString`：可选的 SSR 渲染方法
 

--- a/examples/docs/src/zh/guide/essentials/module-linking.md
+++ b/examples/docs/src/zh/guide/essentials/module-linking.md
@@ -162,7 +162,7 @@ esmx validate          # 人类可读报告
 esmx validate --json   # 机器可读信封（CI / Agent）
 ```
 
-只有出现 error 级诊断时它才以非零码退出；只有警告则退出 0。没有 `esmx` 字段的包会报告 `protocol: "legacy"` 并退出 0。完整诊断分类（`E_NOT_LINKED`、`E_VERSION`、`E_SCHEMA`、`W_MULTI_CANDIDATE` 等）见 [LLM 简报](/llms.md#diagnostics-the-complete-taxonomy)。
+只有出现 error 级诊断时它才以非零码退出；只有警告则退出 0。没有 `esmx` 字段的包会报告 `protocol: "legacy"` 并退出 0。完整诊断分类（`E_NOT_LINKED`、`E_VERSION`、`E_SCHEMA`、`W_MULTI_MAJOR` 等）见 [LLM 简报](/llms.md#diagnostics-the-complete-taxonomy)。
 
 ## 完整示例：多版本共存
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -287,7 +287,7 @@ export class Esmx {
      * const server = http.createServer((req, res) => {
      *     // Use middleware to handle static asset requests
      *     esmx.middleware(req, res, async () => {
-     *         const rc = await esmx.render({ url: req.url });
+     *         const rc = await esmx.render({ params: { url: req.url } });
      *         res.end(rc.html);
      *     });
      * });
@@ -543,6 +543,10 @@ export class Esmx {
         if (previous.app?.destroy) {
             await previous.app.destroy();
         }
+        // Invalidate the cached import-map hash so the new generation re-derives
+        // (and re-writes) its own importmap file instead of reusing the previous
+        // generation's filepath. See getImportMapClientInfo().
+        this._importmapHash = null;
         return true;
     }
 
@@ -1119,7 +1123,7 @@ document.head.appendChild(script);
                 return {
                     src: null,
                     filepath: null,
-                    code: `<script type="importmap">${serialize(importmap, { isJSON: true, unsafe: true })}</script>`,
+                    code: `<script type="importmap">${serialize(importmap, { isJSON: true })}</script>`,
                     integrity: integrity ?? null
                 };
             }

--- a/packages/router/src/scroll.ts
+++ b/packages/router/src/scroll.ts
@@ -98,7 +98,7 @@ export function getSavedScrollPosition(
     key: string,
     defaultValue: _ScrollPosition | null = null
 ): _ScrollPosition | null {
-    const scroll = scrollPositions.get(key) || history.state[POSITION_KEY];
+    const scroll = scrollPositions.get(key) || history.state?.[POSITION_KEY];
 
     // Saved scroll position should not be used multiple times, next time should use newly saved position
     scrollPositions.delete(key);

--- a/packages/router/tests/scroll.dom.test.ts
+++ b/packages/router/tests/scroll.dom.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    getSavedScrollPosition,
+    saveScrollPosition,
+    scrollPositions
+} from '../src/scroll';
+
+describe('scroll position', () => {
+    afterEach(() => {
+        scrollPositions.clear();
+        // Reset history.state to a clean baseline between tests.
+        history.replaceState(null, '');
+    });
+
+    it('does not throw when history.state is null', () => {
+        // Regression guard: getSavedScrollPosition used to dereference
+        // history.state[POSITION_KEY] unconditionally and threw a TypeError
+        // when the browser set history.state to null (new tab, SSR first paint).
+        expect(history.state).toBeNull();
+        expect(() => getSavedScrollPosition('/some/key')).not.toThrow();
+        expect(getSavedScrollPosition('/some/key')).toBeNull();
+    });
+
+    it('returns the default value when nothing is saved and state is null', () => {
+        expect(history.state).toBeNull();
+        const fallback = { left: 10, top: 20 };
+        expect(getSavedScrollPosition('/missing', fallback)).toBe(fallback);
+    });
+
+    it('round-trips a saved position through the in-memory map', () => {
+        const key = '/page/a';
+        const pos = { left: 100, top: 200 };
+        saveScrollPosition(key, pos);
+        expect(getSavedScrollPosition(key)).toEqual(pos);
+    });
+
+    it('consumes the saved position so a second read returns null', () => {
+        const key = '/page/b';
+        saveScrollPosition(key, { left: 1, top: 2 });
+        expect(getSavedScrollPosition(key)).toEqual({ left: 1, top: 2 });
+        // The in-memory entry is deleted after the first read.
+        expect(getSavedScrollPosition(key)).toBeNull();
+    });
+});

--- a/packages/rspack/src/rspack/app.ts
+++ b/packages/rspack/src/rspack/app.ts
@@ -156,7 +156,7 @@ export interface RspackAppOptions {
 
     /**
      * Uses rspack-chain to provide chained configuration method, allowing more flexible modification of Rspack configuration.
-     * Called after the config hook, if chain hook exists, chained configuration is preferred.
+     * Called before the config hook: the chain is applied first, then `chain.toConfig()` produces the final RspackOptions which the config hook may still mutate.
      *
      * @param context - Configuration context, containing framework instance, build target, and chain configuration object
      */


### PR DESCRIPTION
## Summary

Fixes doc-vs-source drift across API docs (en+zh) and 4 runtime bugs found during a full project review.

## Code fixes
- **core `reinit()`**: reset `_importmapHash` so a new generation re-derives its own importmap file instead of reusing the previous generation's path (stale file → hydration failure)
- **core inline importmap**: drop `unsafe: true` on `serialize()` so `</script>` is escaped (XSS hardening). `isJSON`-only output `JSON.parse`s back identically — verified at runtime
- **router `getSavedScrollPosition`**: guard `history.state` null deref (new tab / SSR first paint). Regression test added (`scroll.dom.test.ts`, 4 cases)
- **rspack `chain` JSDoc**: chain runs **before** config, not after (matches `chain-config.ts` real order)

## Doc fixes (en+zh, all cross-checked against source)
- `esmx.md`: `render({url})` → `render({params:{url}})`; param `target`→`env` (3 sites); add `integrity` to `getImportMapClientInfo` return
- `manifest-json.md`: add `protocol`/`version`/`provides`/`uses` + `ManifestJsonProvide` type
- `router.md`: add `resolveLink` to `RouterOptions`
- `types.md`: add `hydration` to `RouterMicroAppOptions`
- `router-react/ssr.md`: `router.route.data` → `router.data`
- `router-react/hooks.md`: `link.href` → `{...link.attributes}`
- `module-linking.md`: `W_MULTI_CANDIDATE` → `W_MULTI_MAJOR`
- `rspack-vue.mdx`: fix dead link → `./rspack#rspackhtmlappoptions`
- `zh dynamic-matching.md`: fix double-escaped regex

## Verification
- core 263 tests ✅ | router 982 (+4) ✅ | rspack 30 ✅ | type checks pass
- Reviewed by 5 independent red-team reviewers; all verified correct