### PR TITLE
fix(husky): point core.hooksPath at .husky to avoid _/ wrapper SIGKILL

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 // Template generation, do not manually modify
 export default {
-    '*.{ts,js,mjs,cjs,vue,css,less}': ['pnpm run lint:js', 'git add .']
+    '*.{ts,js,mjs,cjs,vue,css,less}': ['pnpm run lint:js:fix', 'git add .']
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "type": "module",
     "scripts": {
         "prepare": "node ./prepare.mjs",
-        "lint:js": "biome check --write --no-errors-on-unmatched",
+        "lint:js": "biome check --no-errors-on-unmatched",
+        "lint:js:fix": "biome check --write --no-errors-on-unmatched",
         "lint:css": "pnpm --filter \"*\" lint:css",
         "lint:type": "pnpm --filter \"*\" lint:type",
         "test": "pnpm --filter \"*\" test",

--- a/prepare.mjs
+++ b/prepare.mjs
@@ -4,8 +4,11 @@ import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 
+// Point git directly at .husky/ so hooks in that directory (e.g. pre-commit)
+// run without the husky v9 _/ wrapper, whose generated shim for every hook
+// name gets killed by non-interactive environments and blocks commits.
 try {
-    await execAsync('husky install');
+    await execAsync('git config core.hooksPath .husky');
 } catch (error) {
-    console.log('[33m[WARN][0m Husky not found');
+    console.log('[33m[WARN][0m git not found, skipping hooks setup');
 }


### PR DESCRIPTION
## Problem

Every `git commit` / `checkout` / `pull` in this repo fails with hooks `died of signal 9`, because husky v9's `./husky/_/` wrapper directory generates a shim for **all 14 git hook names**. In non-interactive environments those shims get SIGKILLed on spawn (the project only ships a `pre-commit` hook — the other 13 wrappers are dead weight that gets killed).

Reproduced via `GIT_TRACE`:\n```\ntrace: run_command: .husky/_/prepare-commit-msg .git/COMMIT_EDITMSG message\nerror: .husky/_/prepare-commit-msg died of signal 9   # killed in 2ms\n```\n\nlint-staged itself completes fine — it's the unrelated `prepare-commit-msg` wrapper that blocks the commit.

## Fix

- **`prepare.mjs`**: set `core.hooksPath=.husky` directly instead of calling the deprecated `husky install`. Git now runs `.husky/pre-commit` straight, skipping the `.husky/_/` wrapper entirely. No more spurious hook shims to kill.
- **`lint:js`**: split into read-only `biome check` (`lint:js`) vs `biome check --write` (`lint:js:fix`). The bare `lint:js` no longer rewrites files; `lint-staged` keeps the fix variant via `.lintstagedrc.js`.

## Verification

This PR's own commit was made **through the fixed hook** — `lint-staged` ran `biome check --write` on the 3 staged files and the commit completed cleanly, no `signal 9`. Before the fix, the same flow blocked indefinitely.

```
[COMPLETED] pnpm run lint:js:fix
[COMPLETED] Cleaning up temporary files...
[fix/husky-commit-hook ce518024] fix(husky): ...
 3 files changed, 8 insertions(+), 4 deletions(-)
```